### PR TITLE
fix: getObject for timestamp value  in ClickHouseResultSet

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -306,7 +306,7 @@ public class ClickHouseResultSet extends AbstractResultSet {
                 case Types.VARCHAR:     return getString(columnIndex);
                 case Types.FLOAT:       return getFloat(columnIndex);
                 case Types.DATE:        return getDate(columnIndex);
-                case Types.TIMESTAMP:   return getTime(columnIndex);
+                case Types.TIMESTAMP:   return getTimestamp(columnIndex);
                 case Types.BLOB:        return getString(columnIndex);
             }
             return getString(columnIndex);


### PR DESCRIPTION
There is a wrong getter getObject for timestamp value in ClickHouseResultSet.java. It return java.sql.Time instead java.sql.Timestamp