### PR TITLE
fixed NPE in ClickHouseException

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/except/ClickHouseException.java
+++ b/src/main/java/ru/yandex/clickhouse/except/ClickHouseException.java
@@ -5,10 +5,12 @@ import java.sql.SQLException;
 public class ClickHouseException extends SQLException {
 
     public ClickHouseException(int code, Throwable cause, String host, int port) {
-        super("ClickHouse exception, code: " + code + ", host: " + host + ", port: " + port + "; " + cause.getMessage(), null, code, cause);
+        super("ClickHouse exception, code: " + code + ", host: " + host + ", port: " + port + "; "
+                + (cause == null ? "" : cause.getMessage()), null, code, cause);
     }
 
     public ClickHouseException(int code, String message, Throwable cause, String host, int port) {
-        super("ClickHouse exception, message: " + message + ", host: " + host + ", port: " + port + "; " + cause.getMessage(), null, code, cause);
+        super("ClickHouse exception, message: " + message + ", host: " + host + ", port: " + port + "; "
+                + (cause == null ? "" : cause.getMessage()), null, code, cause);
     }
 }


### PR DESCRIPTION
connecting to ```jdbc:clickhouse://localhost:8123``` using DataGrip
```
sql> show table
[1002] ClickHouse exception, code: 1002, host: localhost, port: 8123; null java.lang.NullPointerException
	at ru.yandex.clickhouse.except.ClickHouseException.<init>(ClickHouseException.java:12)
	at ru.yandex.clickhouse.except.ClickHouseUnknownException.<init>(ClickHouseUnknownException.java:11)
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:60)
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:27)
	at ru.yandex.clickhouse.ClickHouseStatementImpl.getInputStream(ClickHouseStatementImpl.java:439)
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:79)
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:75)
	at ru.yandex.clickhouse.ClickHouseStatementImpl.execute(ClickHouseStatementImpl.java:142)
```