### PR TITLE
pass database from jdbc url to Driver

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -37,7 +37,7 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     public ClickHouseConnectionImpl(String url, ClickHouseProperties properties) {
         this.properties = properties;
-        this.dataSource = new ClickHouseDataSource(url);
+        this.dataSource = new ClickHouseDataSource(url, properties);
         ClickHouseHttpClientBuilder clientBuilder = new ClickHouseHttpClientBuilder(properties);
         log.debug("new connection");
         httpclient = clientBuilder.buildClient();

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
@@ -62,8 +62,8 @@ public class ClickHouseDataSource implements DataSource {
         } else {
             throw new IllegalArgumentException("Incorrect ClickHouse jdbc url: " + url);
         }
+        properties.setDatabase(database);
         this.properties = new ClickHouseProperties(properties);
-        this.properties.setDatabase(database);
     }
 
     @Override


### PR DESCRIPTION
Default database name from jdbc url is not used by ClickHouseStatementImpl if connection was created using ClickHouseDriver.
```
Driver driver = new ClickHouseDriver();
Connection connection = driver.connect("jdbc:clickhouse://localhost:8123/test", new Properties());
Statement statement = connection.createStatement();
ResultSet rs = statement.executeQuery("select * from table limit 1"); // fails, but works with test.table
while (rs.next()) {
    System.out.println(rs.getMetaData().getColumnCount());
}
statement.close();
```