### PR TITLE
jdbc driver should not fail on fetchSize hint

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -477,4 +477,15 @@ public class ClickHouseResultSet extends AbstractResultSet {
         BigDecimal result = new BigDecimal(string);
         return result.setScale(scale, BigDecimal.ROUND_HALF_UP);
     }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        // ignore perfomance hint
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        // ignore perfomance hint
+    }
+
 }


### PR DESCRIPTION
```setFetchDirection``` and ```setFetchSize``` are performance hints and may be ignored by the driver.
Throwing UnsupportedOperationException breaks RJDBC, see https://github.com/s-u/RJDBC/pull/11
