### PR TITLE
Skip jdbc url to another DB

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
@@ -45,6 +45,9 @@ public class ClickHouseDriver implements Driver {
 
     @Override
     public ClickHouseConnection connect(String url, Properties info) throws SQLException {
+        if (!acceptsURL(url)) {
+            return null;
+        }
         logger.info("Creating connection");
         ClickHouseConnectionImpl connection = new ClickHouseConnectionImpl(url, info);
         registerConnection(connection);
@@ -52,6 +55,9 @@ public class ClickHouseDriver implements Driver {
     }
 
     public ClickHouseConnection connect(String url, ClickHouseProperties properties) throws SQLException {
+        if (!acceptsURL(url)) {
+            return null;
+        }
         logger.info("Creating connection");
         ClickHouseConnectionImpl connection = new ClickHouseConnectionImpl(url, properties);
         registerConnection(connection);


### PR DESCRIPTION
If project includes a series of database drivers it gets a problem because ClickHouse driver tries to handle jdbc url to another DB.