### PR TITLE
Ability to use driver with Pentaho Report Designer

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -1,5 +1,12 @@
 package ru.yandex.clickhouse;
 
+import java.io.IOException;
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,13 +14,6 @@ import ru.yandex.clickhouse.except.ClickHouseUnknownException;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.util.ClickHouseHttpClientBuilder;
 import ru.yandex.clickhouse.util.LogProxy;
-
-import java.io.IOException;
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 
 
 public class ClickHouseConnectionImpl implements ClickHouseConnection {
@@ -173,7 +173,7 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return createPreparedStatement(sql);
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -1,5 +1,18 @@
 package ru.yandex.clickhouse;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
@@ -23,19 +36,6 @@ import ru.yandex.clickhouse.util.Patterns;
 import ru.yandex.clickhouse.util.Utils;
 import ru.yandex.clickhouse.util.apache.StringUtils;
 import ru.yandex.clickhouse.util.guava.StreamUtils;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLWarning;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 
 public class ClickHouseStatementImpl implements ClickHouseStatement {
@@ -83,7 +83,8 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
                 currentResult = new ClickHouseResultSet(properties.isCompress()
                         ? new ClickHouseLZ4Stream(is) : is, properties.getBufferSize(),
                         extractDBName(sql),
-                        extractTableName(sql)
+                        extractTableName(sql),
+                        this
                 );
                 currentResult.setMaxRows(maxRows);
                 return currentResult;

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
@@ -69,7 +69,7 @@ public class ClickHouseResultBuilder {
             byte[] bytes = baos.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
-            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown");
+            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown", null);
         } catch (IOException e) {
             throw new RuntimeException("Never happens", e);
         }

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -1,7 +1,5 @@
 package ru.yandex.clickhouse.response;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -11,6 +9,9 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ClickHouseResultSet extends AbstractResultSet {
@@ -42,9 +43,13 @@ public class ClickHouseResultSet extends AbstractResultSet {
     // row counter
     private int rowNumber;
 
-    public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table) throws IOException {
+    // statement result set belongs to
+    private Statement statement;
+
+    public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table, Statement statement) throws IOException {
         this.db = db;
         this.table = table;
+        this.statement = statement;
         bis = new StreamSplitter(is, (byte) 0x0A, bufferSize);  ///   \n
         ByteFragment headerFragment = bis.next();
         if (headerFragment == null) {
@@ -288,6 +293,11 @@ public class ClickHouseResultSet extends AbstractResultSet {
         }
     }
 
+    @Override
+    public Statement getStatement() {
+        return statement;
+    }
+    
     @Override
     public Date getDate(int columnIndex) throws SQLException {
         // date is passed as a string from clickhouse


### PR DESCRIPTION
Changes that makes driver work correctly with Pentaho:
Added "statement"  attribute to ClickHouseResultSet and all constructors.
Added stub to  prepareStatement(String sql, int resultSetType, int resultSetConcurrency)