### PR TITLE
Support IPv6 in JDBC URL

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
@@ -19,7 +19,7 @@ public class ClickHouseDataSource implements DataSource {
     protected final static Pattern urlRegexp;
 
     static {
-        urlRegexp = Pattern.compile("^jdbc:clickhouse://([a-zA-Z0-9.-]+):([0-9]+)(?:|/|/([a-zA-Z0-9_]+))$");
+        urlRegexp = Pattern.compile("^jdbc:clickhouse://([a-zA-Z0-9.-]+|\\[[:.a-fA-F0-9]+\\]):([0-9]+)(?:|/|/([a-zA-Z0-9_]+))$");
     }
 
     protected final static String DEFAULT_DATABASE = "default";

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseDataSourceTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseDataSourceTest.java
@@ -42,4 +42,17 @@ public class ClickHouseDataSourceTest {
         }
     }
 
+    @Test
+    public void testIPv6Constructor() throws Exception {
+        ClickHouseDataSource ds = new ClickHouseDataSource("jdbc:clickhouse://[::1]:5324");
+        assertEquals(ds.getHost(), "[::1]");
+        assertEquals(ds.getPort(), 5324);
+        assertEquals(ds.getDatabase(), "default");
+
+        ClickHouseDataSource ds2 = new ClickHouseDataSource("jdbc:clickhouse://[::FFFF:129.144.52.38]:5324");
+        assertEquals(ds2.getHost(), "[::FFFF:129.144.52.38]");
+        assertEquals(ds2.getPort(), 5324);
+        assertEquals(ds2.getDatabase(), "default");
+    }
+
 }


### PR DESCRIPTION
[RFC 2732](http://www.ietf.org/rfc/rfc2732.txt) IPv6 Literal Addresses in URL's 