### PR TITLE
introduce sql driver auto-load meta-file

### DIFF
--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+ru.yandex.clickhouse.ClickHouseDriver


### PR DESCRIPTION
Этот файл позволит не делать Class.forName("ru.yandex.clickhouse.ClickHouseDriver"). Он не требуется в случае ClickHouseDataSource, но упрощает работу с другими DataSources. 
Подробности: https://docs.oracle.com/javase/8/docs/api/java/sql/DriverManager.html