### PR TITLE
Add enum binding parameter support

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -289,6 +289,8 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
                 setClob(parameterIndex, (Clob) x);
             } else if (x instanceof BigInteger) {
                 setString(parameterIndex, x.toString());
+            } else if (x instanceof Enum) {
+                setString(parameterIndex, ((Enum) x).name());
             } else if (x instanceof Collection) {
                 setBind(parameterIndex, ClickHouseArrayUtil.toString((Collection) x));
             } else if (x.getClass().isArray()) {


### PR DESCRIPTION
It is nice to be able to pass enum as a parameter for sql query. This minifix add's this possibility. Enum is transformed to String, because it is recommended way of saving enums to database since Archimedes. Have never seen anyone who uses ordinal for this.