### PR TITLE
Jdbc compliance improvements

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
@@ -4,6 +4,7 @@ import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import javax.sql.DataSource;
 import java.io.PrintWriter;
+import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -15,21 +16,10 @@ import java.util.regex.Pattern;
 
 
 public class ClickHouseDataSource implements DataSource {
-
-    protected final static Pattern urlRegexp = Pattern.compile("^jdbc:clickhouse://([a-zA-Z0-9.-]+|\\[[:.a-fA-F0-9]+\\]):([0-9]+)(?:|/|/([a-zA-Z0-9_]+))$");
-
-    protected final static String DEFAULT_DATABASE = "default";
-
     protected final ClickHouseDriver driver = new ClickHouseDriver();
-
     protected final String url;
-    protected String host;
-    protected int port;
-    protected String database;
-
-    PrintWriter printWriter;
+    protected PrintWriter printWriter;
     protected int loginTimeout = 0;
-
     private ClickHouseProperties properties;
 
     public ClickHouseDataSource(String url) {
@@ -45,21 +35,11 @@ public class ClickHouseDataSource implements DataSource {
             throw new IllegalArgumentException("Incorrect ClickHouse jdbc url: " + url);
         }
         this.url = url;
-
-        Matcher m = urlRegexp.matcher(url);
-        if (m.find()) {
-            this.host = m.group(1);
-            this.port = Integer.parseInt(m.group(2));
-            if (m.group(3) != null) {
-                this.database = m.group(3);
-            } else {
-                this.database = properties.getDatabase() == null ? DEFAULT_DATABASE : properties.getDatabase();
-            }
-        } else {
-            throw new IllegalArgumentException("Incorrect ClickHouse jdbc url: " + url);
+        try {
+            this.properties =  ClickhouseJdbcUrlParser.parse(url, properties.asProperties());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
         }
-        this.properties = new ClickHouseProperties(properties);
-        this.properties.setDatabase(database);
     }
 
     @Override
@@ -73,15 +53,15 @@ public class ClickHouseDataSource implements DataSource {
     }
 
     public String getHost() {
-        return host;
+        return properties.getHost();
     }
 
     public int getPort() {
-        return port;
+        return properties.getPort();
     }
 
     public String getDatabase() {
-        return database;
+        return properties.getDatabase();
     }
 
     public String getUrl() {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
@@ -98,12 +98,15 @@ public class ClickHouseDataSource implements DataSource {
 
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        return null;
+        if (iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new SQLException("Cannot unwrap to " + iface.getName());
     }
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException("Not implemented");
+        return iface.isAssignableFrom(getClass());
     }
 
     /**

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -1235,12 +1235,15 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        return null;
+        if (iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new SQLException("Cannot unwrap to " + iface.getName());
     }
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return false;
+        return iface.isAssignableFrom(getClass());
     }
 
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -837,7 +837,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
             //IS_NULLABLE
             row.add("NO");
 
-            //"SCOPE_CATLOG",
+            //"SCOPE_CATALOG",
             row.add(null);
             //"SCOPE_SCHEMA",
             row.add(null);
@@ -875,7 +875,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
                 "CHAR_OCTET_LENGTH",
                 "ORDINAL_POSITION",
                 "IS_NULLABLE",
-                "SCOPE_CATLOG",
+                "SCOPE_CATALOG",
                 "SCOPE_SCHEMA",
                 "SCOPE_TABLE",
                 "SOURCE_DATA_TYPE",

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -4,10 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.yandex.clickhouse.response.ClickHouseResultBuilder;
 import ru.yandex.clickhouse.util.TypeUtils;
-import ru.yandex.clickhouse.util.Utils;
 
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 
@@ -17,8 +17,8 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
 
     private static final Logger log = LoggerFactory.getLogger(ClickHouseDatabaseMetadata.class);
 
-    private String url;
-    private ClickHouseConnection connection;
+    private final String url;
+    private final ClickHouseConnection connection;
 
     public ClickHouseDatabaseMetadata(String url, ClickHouseConnection connection) {
         this.url = url;
@@ -748,11 +748,113 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
         return request("select 'TABLE', 'LOCAL TEMPORARY'");
     }
 
+    private static void buildAndCondition(StringBuilder dest, List<String> conditions) {
+        Iterator<String> iter = conditions.iterator();
+        if (iter.hasNext()) {
+            String entry = iter.next();
+            dest.append(entry);
+        }
+        while (iter.hasNext()) {
+            String entry = iter.next();
+            dest.append(" AND ").append(entry);
+        }
+    }
+
     @Override
     public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
-        // todo support patterns as it should be (how?!)
-        log.debug("getColumns: cat " + catalog + " sp " + schemaPattern +
-            " tnp " + tableNamePattern + " cnp " + columnNamePattern);
+        StringBuilder query = new StringBuilder("SELECT database, table, name, type, default_type, default_expression ");
+        query.append("FROM system.columns ");
+        List<String> predicates = new ArrayList<String>();
+        if (schemaPattern != null) {
+            predicates.add("database LIKE '" + schemaPattern + "' ");
+        }
+        if (tableNamePattern != null) {
+            predicates.add("table LIKE '" + tableNamePattern + "' ");
+        }
+        if (columnNamePattern != null) {
+            predicates.add("name LIKE '" + columnNamePattern + "' ");
+        }
+        if (!predicates.isEmpty()) {
+            query.append(" WHERE ");
+            buildAndCondition(query, predicates);
+        }
+        ClickHouseResultBuilder builder = getClickHouseResultBuilderForGetColumns();
+        ResultSet descTable = request(query.toString());
+        int colNum = 1;
+        while (descTable.next()) {
+            List<String> row = new ArrayList<String>();
+            //catalog name
+            row.add(DEFAULT_CAT);
+            //database name
+            row.add(descTable.getString(1));
+            //table name
+            row.add(descTable.getString(2));
+            //column name
+            row.add(descTable.getString(3));
+            String type = descTable.getString(4);
+            int sqlType = TypeUtils.toSqlType(type);
+            //data type
+            row.add(Integer.toString(sqlType));
+            //type name
+            row.add(type);
+            // column size ?
+            row.add("0");
+            //buffer length
+            row.add("0");
+
+            // decimal digits
+            if (sqlType == Types.INTEGER || sqlType == Types.BIGINT && type.contains("Int")) {
+                String bits = type.substring(type.indexOf("Int") + "Int".length());
+                row.add(bits);
+            } else {
+                row.add(null);
+            }
+
+            // radix
+            row.add("10");
+            // nullable
+            row.add(String.valueOf(columnNoNulls));
+            //remarks
+            row.add(null);
+
+            // COLUMN_DEF
+            if ( descTable.getString( 3 ).equals( "DEFAULT" ) ) {
+                row.add( descTable.getString( 4 ) );
+            } else {
+                row.add( null );
+            }
+
+            //"SQL_DATA_TYPE", unused per JavaDoc
+            row.add(null);
+            //"SQL_DATETIME_SUB", unused per JavaDoc
+            row.add(null);
+
+            // char octet length
+            row.add("0");
+            // ordinal
+            row.add(String.valueOf(colNum));
+            colNum += 1;
+            //IS_NULLABLE
+            row.add("NO");
+
+            //"SCOPE_CATLOG",
+            row.add(null);
+            //"SCOPE_SCHEMA",
+            row.add(null);
+            //"SCOPE_TABLE",
+            row.add(null);
+            //"SOURCE_DATA_TYPE",
+            row.add(null);
+            //"IS_AUTOINCREMENT"
+            row.add(null);
+
+            builder.addRow(row);
+        }
+        descTable.close();
+        return builder.build();
+    }
+
+    private ClickHouseResultBuilder getClickHouseResultBuilderForGetColumns() {
         ClickHouseResultBuilder builder = ClickHouseResultBuilder.builder(23);
         builder.names(
                 "TABLE_CAT",
@@ -804,76 +906,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
                 "Int32",
                 "String"
         );
-        // todo use system.columns
-        String sql = "desc table ";
-        if (schemaPattern != null) {
-            sql += Utils.unEscapeString(schemaPattern) + '.';
-        }
-        sql += Utils.unEscapeString(tableNamePattern);
-        ResultSet descTable = request(sql);
-        int colNum = 1;
-        while (descTable.next()) {
-            // column filter
-            if (columnNamePattern != null && !columnNamePattern.equals(descTable.getString(1))
-                    && !columnNamePattern.equals("%")) {
-                continue;
-            }
-            List<String> row = new ArrayList<String>();
-            row.add(DEFAULT_CAT);
-            row.add(schemaPattern);
-            row.add(tableNamePattern);
-            row.add(descTable.getString(1));
-            String type = descTable.getString(2);
-            int sqlType = TypeUtils.toSqlType(type);
-            row.add(Integer.toString(sqlType));
-            row.add(type);
-
-            // column size ?
-            row.add("0");
-            row.add("0");
-
-            // decimal digits
-            if (sqlType == Types.INTEGER || sqlType == Types.BIGINT && type.contains("Int")) {
-                String bits = type.substring(type.indexOf("Int") + "Int".length());
-                row.add(bits);
-            } else {
-                row.add(null);
-            }
-
-            // radix
-            row.add("10");
-            // nullable
-            row.add(String.valueOf(columnNoNulls));
-
-            row.add(null);
-            // COLUMN_DEF
-            if ( descTable.getString( 3 ).equals( "DEFAULT" ) ) {
-                row.add( descTable.getString( 4 ) );
-            } else {
-                row.add( null );
-            }
-            row.add(null);
-            row.add(null);
-
-            // char octet length
-            row.add("0");
-            // ordinal
-            row.add(String.valueOf(colNum));
-            colNum += 1;
-            row.add("NO");
-
-            row.add(null);
-            row.add(null);
-            row.add(null);
-            row.add(null);
-            row.add(null);
-
-            builder.addRow(row);
-
-        }
-        descTable.close();
-
-        return builder.build();
+        return builder;
     }
 
     private ResultSet getEmptyResultSet() {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import ru.yandex.clickhouse.settings.ClickHouseConnectionSettings;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
-import ru.yandex.clickhouse.settings.DriverPropertyInfoAware;
+import ru.yandex.clickhouse.settings.DriverPropertyCreator;
 import ru.yandex.clickhouse.util.LogProxy;
 import java.sql.*;
 import java.util.ArrayList;
@@ -93,10 +93,10 @@ public class ClickHouseDriver implements Driver {
         return result.toArray(new DriverPropertyInfo[result.size()]);
     }
 
-    private List<DriverPropertyInfo> dumpProperties(DriverPropertyInfoAware infoAware[], Properties info) {
-        List<DriverPropertyInfo> result = new ArrayList<DriverPropertyInfo>(infoAware.length);
-        for (int i = 0; i < infoAware.length; ++i) {
-            result.add(infoAware[i].toDriverPropertyInfo(info));
+    private List<DriverPropertyInfo> dumpProperties(DriverPropertyCreator creators[], Properties info) {
+        List<DriverPropertyInfo> result = new ArrayList<DriverPropertyInfo>(creators.length);
+        for (int i = 0; i < creators.length; ++i) {
+            result.add(creators[i].createDriverPropertyInfo(info));
         }
         return result;
     }

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.util.LogProxy;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.sql.*;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentMap;
@@ -19,9 +21,9 @@ import java.util.concurrent.TimeUnit;
  *
  * primitive for now
  *
- * jdbc:clickhouse:host:port
+ * jdbc:clickhouse://host:port
  *
- * for example, jdbc:clickhouse:localhost:8123
+ * for example, jdbc:clickhouse://localhost:8123
  *
  */
 public class ClickHouseDriver implements Driver {

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -32,10 +32,9 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
     private boolean[] valuesQuote;
     private List<byte[]> batchRows = new ArrayList<byte[]>();
 
-    public ClickHousePreparedStatementImpl(CloseableHttpClient client, ClickHouseDataSource source,
-                                           ClickHouseConnection connection, ClickHouseProperties properties,
-                                           String sql) throws SQLException {
-        super(client, source, connection, properties);
+    public ClickHousePreparedStatementImpl(CloseableHttpClient client, ClickHouseConnection connection,
+             ClickHouseProperties properties, String sql) throws SQLException {
+        super(client, connection, properties);
         this.sql = sql;
         this.sqlParts = parseSql(sql);
         createBinds();

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -331,12 +331,15 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
 
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        return null;
+        if (iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new SQLException("Cannot unwrap to " + iface.getName());
     }
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return false;
+        return iface.isAssignableFrom(getClass());
     }
 
     static String clickhousifySql(String sql) {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -211,7 +211,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
 
     @Override
     public int getUpdateCount() throws SQLException {
-        return 0;
+        return currentResult == null ? 0 : -1;
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
@@ -1,0 +1,84 @@
+package ru.yandex.clickhouse;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
+
+public class ClickhouseJdbcUrlParser {
+    private static final Logger logger = LoggerFactory.getLogger(ClickhouseJdbcUrlParser.class);
+    public static final String JDBC_PREFIX = "jdbc:";
+    public static final String JDBC_CLICKHOUSE_PREFIX = JDBC_PREFIX + "clickhouse:";
+    public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
+    protected final static String DEFAULT_DATABASE = "default";
+
+    private ClickhouseJdbcUrlParser(){
+    }
+
+    public static ClickHouseProperties parse(String jdbcUrl, Properties defaults) throws URISyntaxException
+    {
+        if (!jdbcUrl.startsWith(JDBC_CLICKHOUSE_PREFIX)) {
+            throw new URISyntaxException(jdbcUrl, "'" + JDBC_CLICKHOUSE_PREFIX + "' prefix is mandatory");
+        }
+        return parseClickhouseUrl(jdbcUrl.substring(JDBC_PREFIX.length()), defaults);
+    }
+
+    private static ClickHouseProperties parseClickhouseUrl(String uriString, Properties defaults)
+            throws URISyntaxException
+    {
+        URI uri = new URI(uriString);
+        Properties urlProperties = parseUriQueryPart(uri, defaults);
+        ClickHouseProperties props = new ClickHouseProperties(urlProperties);
+        props.setHost(uri.getHost());
+        int port = uri.getPort();
+        if (port == -1) {
+            throw new IllegalArgumentException("port is missed or wrong");
+        }
+        props.setPort(port);
+        String database = uri.getPath();
+        if (database == null || database.isEmpty()) {
+            String defaultsDb = (String)defaults.get(ClickHouseQueryParam.DATABASE.getKey());
+            database = defaultsDb == null ? DEFAULT_DATABASE : defaultsDb;
+        } else {
+            Matcher m = DB_PATH_PATTERN.matcher(database);
+            if (m.matches()) {
+                database = m.group(1);
+            } else {
+                throw new URISyntaxException("wrong database name path: '" + database + "'", uriString);
+            }
+        }
+        props.setDatabase(database);
+        return props;
+    }
+
+    private static Properties parseUriQueryPart(URI uri, Properties defaults) {
+        String query = uri.getQuery();
+        if (query == null) {
+            return defaults;
+        }
+        Properties urlProps = new Properties(defaults);
+        String queryKeyVaues[] = query.split("&");
+        for (String keyValue : queryKeyVaues) {
+            String keyValueTokens[] = keyValue.split("=");
+            if (keyValueTokens.length == 2) {
+                urlProps.put(keyValueTokens[0], keyValueTokens[1]);
+            } else {
+                logger.warn("don't know how to handle parameter pair: {}", keyValue);
+            }
+        }
+        return urlProps;
+    }
+
+    public static void main(String[] args) throws URISyntaxException {
+        ClickHouseProperties props = ClickhouseJdbcUrlParser.parse("jdbc:clickhouse://localhost:wer", new Properties());
+        System.err.println(props.getDatabase());
+        System.err.println(props.getPort());
+    }
+}

--- a/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
@@ -75,10 +75,4 @@ public class ClickhouseJdbcUrlParser {
         }
         return urlProps;
     }
-
-    public static void main(String[] args) throws URISyntaxException {
-        ClickHouseProperties props = ClickhouseJdbcUrlParser.parse("jdbc:clickhouse://localhost:wer", new Properties());
-        System.err.println(props.getDatabase());
-        System.err.println(props.getPort());
-    }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -3,37 +3,39 @@ package ru.yandex.clickhouse.settings;
 
 public enum ClickHouseConnectionSettings {
 
-    ASYNC("async", false),
-    BUFFER_SIZE("buffer_size", 65536),
-    APACHE_BUFFER_SIZE("apache_buffer_size", 65536),
-    SOCKET_TIMEOUT("socket_timeout", 30000),
-    CONNECTION_TIMEOUT("connection_timeout", 50),
+    ASYNC("async", false, "FIXME"),
+    BUFFER_SIZE("buffer_size", 65536, "FIXME"),
+    APACHE_BUFFER_SIZE("apache_buffer_size", 65536, "FIXME"),
+    SOCKET_TIMEOUT("socket_timeout", 30000, "FIXME"),
+    CONNECTION_TIMEOUT("connection_timeout", 50, "FIXME"),
 
     /*
     * this is a timeout for data transfer
     * socketTimeout + dataTransferTimeout is sent to ClickHouse as max_execution_time
     * ClickHouse rejects request execution if its time exceeds max_execution_time
     * */
-    DATA_TRANSFER_TIMEOUT( "dataTransferTimeout", 10000),
+    DATA_TRANSFER_TIMEOUT( "dataTransferTimeout", 10000, "FIXME"),
 
 
-    KEEP_ALIVE_TIMEOUT("keepAliveTimeout", 30 * 1000),
+    KEEP_ALIVE_TIMEOUT("keepAliveTimeout", 30 * 1000, "FIXME"),
 
     /**
      * for ConnectionManager
      */
-    TIME_TO_LIVE_MILLIS("timeToLiveMillis", 60*1000),
-    DEFAULT_MAX_PER_ROUTE("defaultMaxPerRoute", 500),
-    MAX_TOTAL("maxTotal", 10000);
+    TIME_TO_LIVE_MILLIS("timeToLiveMillis", 60*1000, "FIXME"),
+    DEFAULT_MAX_PER_ROUTE("defaultMaxPerRoute", 500, "FIXME"),
+    MAX_TOTAL("maxTotal", 10000, "FIXME");
 
     private final String key;
     private final Object defaultValue;
+    private final String description;
     private final Class clazz;
 
-    ClickHouseConnectionSettings(String key, Object defaultValue) {
+    ClickHouseConnectionSettings(String key, Object defaultValue, String description) {
         this.key = key;
         this.defaultValue = defaultValue;
         this.clazz = defaultValue.getClass();
+        this.description = description;
     }
 
     public String getKey() {
@@ -46,5 +48,9 @@ public enum ClickHouseConnectionSettings {
 
     public Class getClazz() {
         return clazz;
+    }
+
+    public String getDescription() {
+        return description;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -4,7 +4,7 @@ package ru.yandex.clickhouse.settings;
 import java.sql.DriverPropertyInfo;
 import java.util.Properties;
 
-public enum ClickHouseConnectionSettings implements DriverPropertyInfoAware {
+public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
 
     ASYNC("async", false, ""),
     BUFFER_SIZE("buffer_size", 65536, ""),
@@ -57,7 +57,7 @@ public enum ClickHouseConnectionSettings implements DriverPropertyInfoAware {
         return description;
     }
 
-    public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
+    public DriverPropertyInfo createDriverPropertyInfo(Properties properties) {
         DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, driverPropertyValue(properties));
         propertyInfo.required = false;
         propertyInfo.description = description;

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -1,7 +1,10 @@
 package ru.yandex.clickhouse.settings;
 
 
-public enum ClickHouseConnectionSettings {
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+
+public enum ClickHouseConnectionSettings implements DriverPropertyInfoAware {
 
     ASYNC("async", false, "FIXME"),
     BUFFER_SIZE("buffer_size", 65536, "FIXME"),
@@ -52,5 +55,13 @@ public enum ClickHouseConnectionSettings {
 
     public String getDescription() {
         return description;
+    }
+
+    public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
+        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, properties.getProperty(key));
+        propertyInfo.required = false;
+        propertyInfo.description = description;
+        propertyInfo.choices = null;
+        return propertyInfo;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -6,28 +6,28 @@ import java.util.Properties;
 
 public enum ClickHouseConnectionSettings implements DriverPropertyInfoAware {
 
-    ASYNC("async", false, "FIXME"),
-    BUFFER_SIZE("buffer_size", 65536, "FIXME"),
-    APACHE_BUFFER_SIZE("apache_buffer_size", 65536, "FIXME"),
-    SOCKET_TIMEOUT("socket_timeout", 30000, "FIXME"),
-    CONNECTION_TIMEOUT("connection_timeout", 50, "FIXME"),
+    ASYNC("async", false, ""),
+    BUFFER_SIZE("buffer_size", 65536, ""),
+    APACHE_BUFFER_SIZE("apache_buffer_size", 65536, ""),
+    SOCKET_TIMEOUT("socket_timeout", 30000, ""),
+    CONNECTION_TIMEOUT("connection_timeout", 50, ""),
 
     /*
-    * this is a timeout for data transfer
-    * socketTimeout + dataTransferTimeout is sent to ClickHouse as max_execution_time
-    * ClickHouse rejects request execution if its time exceeds max_execution_time
+    *
     * */
-    DATA_TRANSFER_TIMEOUT( "dataTransferTimeout", 10000, "FIXME"),
+    DATA_TRANSFER_TIMEOUT( "dataTransferTimeout", 10000, "Timeout for data transfer. "
+            + " socketTimeout + dataTransferTimeout is sent to ClickHouse as max_execution_time. "
+            + " ClickHouse rejects request execution if its time exceeds max_execution_time"),
 
 
-    KEEP_ALIVE_TIMEOUT("keepAliveTimeout", 30 * 1000, "FIXME"),
+    KEEP_ALIVE_TIMEOUT("keepAliveTimeout", 30 * 1000, ""),
 
     /**
      * for ConnectionManager
      */
-    TIME_TO_LIVE_MILLIS("timeToLiveMillis", 60*1000, "FIXME"),
-    DEFAULT_MAX_PER_ROUTE("defaultMaxPerRoute", 500, "FIXME"),
-    MAX_TOTAL("maxTotal", 10000, "FIXME");
+    TIME_TO_LIVE_MILLIS("timeToLiveMillis", 60 * 1000, ""),
+    DEFAULT_MAX_PER_ROUTE("defaultMaxPerRoute", 500, ""),
+    MAX_TOTAL("maxTotal", 10000, "");
 
     private final String key;
     private final Object defaultValue;
@@ -58,10 +58,22 @@ public enum ClickHouseConnectionSettings implements DriverPropertyInfoAware {
     }
 
     public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
-        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, properties.getProperty(key));
+        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, driverPropertyValue(properties));
         propertyInfo.required = false;
         propertyInfo.description = description;
-        propertyInfo.choices = null;
+        propertyInfo.choices = driverPropertyInfoChoices();
         return propertyInfo;
+    }
+
+    private String[] driverPropertyInfoChoices() {
+        return clazz == Boolean.class || clazz == Boolean.TYPE ? new String[]{"true", "false"} : null;
+    }
+
+    private String driverPropertyValue(Properties properties) {
+        String value = properties.getProperty(key);
+        if (value == null) {
+            value = defaultValue == null ? null : defaultValue.toString();
+        }
+        return value;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -20,6 +20,8 @@ public class ClickHouseProperties {
     private int timeToLiveMillis;
     private int defaultMaxPerRoute;
     private int maxTotal;
+    private String host;
+    private int port;
 
 
     // queries settings
@@ -71,8 +73,39 @@ public class ClickHouseProperties {
         this.user = getSetting(info, ClickHouseQueryParam.USER);
         this.password = getSetting(info, ClickHouseQueryParam.PASSWORD);
     }
+    public Properties asProperties() {
+        PropertiesBuilder ret = new PropertiesBuilder();
+        ret.put(ClickHouseConnectionSettings.ASYNC.getKey(), async);
+        ret.put(ClickHouseConnectionSettings.BUFFER_SIZE.getKey(), bufferSize);
+        ret.put(ClickHouseConnectionSettings.APACHE_BUFFER_SIZE.getKey(), apacheBufferSize);
+        ret.put(ClickHouseConnectionSettings.SOCKET_TIMEOUT.getKey(), socketTimeout);
+        ret.put(ClickHouseConnectionSettings.CONNECTION_TIMEOUT.getKey(), connectionTimeout);
+        ret.put(ClickHouseConnectionSettings.DATA_TRANSFER_TIMEOUT.getKey(), dataTransferTimeout);
+        ret.put(ClickHouseConnectionSettings.KEEP_ALIVE_TIMEOUT.getKey(), keepAliveTimeout);
+        ret.put(ClickHouseConnectionSettings.TIME_TO_LIVE_MILLIS.getKey(), timeToLiveMillis);
+        ret.put(ClickHouseConnectionSettings.DEFAULT_MAX_PER_ROUTE.getKey(), defaultMaxPerRoute);
+        ret.put(ClickHouseConnectionSettings.MAX_TOTAL.getKey(), maxTotal);
+
+        ret.put(ClickHouseQueryParam.MAX_PARALLEL_REPLICAS.getKey(), maxParallelReplicas);
+        ret.put(ClickHouseQueryParam.TOTALS_MODE.getKey(), totalsMode);
+        ret.put(ClickHouseQueryParam.QUOTA_KEY.getKey(), quotaKey);
+        ret.put(ClickHouseQueryParam.PRIORITY.getKey(), priority);
+        ret.put(ClickHouseQueryParam.DATABASE.getKey(), database);
+        ret.put(ClickHouseQueryParam.COMPRESS.getKey(), compress);
+        ret.put(ClickHouseQueryParam.EXTREMES.getKey(), extremes);
+        ret.put(ClickHouseQueryParam.MAX_THREADS.getKey(), maxThreads);
+        ret.put(ClickHouseQueryParam.MAX_EXECUTION_TIME.getKey(), maxExecutionTime);
+        ret.put(ClickHouseQueryParam.MAX_BLOCK_SIZE.getKey(), maxBlockSize);
+        ret.put(ClickHouseQueryParam.MAX_ROWS_TO_GROUP_BY.getKey(), maxRowsToGroupBy);
+        ret.put(ClickHouseQueryParam.PROFILE.getKey(), profile);
+        ret.put(ClickHouseQueryParam.USER.getKey(), user);
+        ret.put(ClickHouseQueryParam.PASSWORD.getKey(), password);
+        return ret.getProperties();
+    }
 
     public ClickHouseProperties(ClickHouseProperties properties) {
+        setHost(properties.host);
+        setPort(properties.port);
         setAsync(properties.async);
         setBufferSize(properties.bufferSize);
         setApacheBufferSize(properties.apacheBufferSize);
@@ -99,7 +132,7 @@ public class ClickHouseProperties {
         setPassword(properties.password);
     }
 
-    public Map<ClickHouseQueryParam, String> buildParams(boolean ignoreDatabase){
+    public Map<ClickHouseQueryParam, String> buildQueryParams(boolean ignoreDatabase){
         Map<ClickHouseQueryParam, String> params = new HashMap<ClickHouseQueryParam, String>();
 
         if (maxParallelReplicas != null) params.put(ClickHouseQueryParam.MAX_PARALLEL_REPLICAS, String.valueOf(maxParallelReplicas));
@@ -361,5 +394,52 @@ public class ClickHouseProperties {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    private static class PropertiesBuilder {
+        private final Properties properties;
+        public PropertiesBuilder() {
+            properties = new Properties();
+        }
+
+        public void put(String key, int value) {
+            properties.put(key, value);
+        }
+
+        public void put(String key, Integer value) {
+            if (value != null) {
+                properties.put(key, value.toString());
+            }
+        }
+
+        public void put(String key, boolean value) {
+            properties.put(key, String.valueOf(value));
+        }
+
+        public void put(String key, String value) {
+            if (value != null) {
+                properties.put(key, value);
+            }
+        }
+
+        public Properties getProperties() {
+            return properties;
+        }
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -116,6 +116,7 @@ public class ClickHouseProperties {
         setTimeToLiveMillis(properties.timeToLiveMillis);
         setDefaultMaxPerRoute(properties.defaultMaxPerRoute);
         setMaxTotal(properties.maxTotal);
+
         setMaxParallelReplicas(properties.maxParallelReplicas);
         setTotalsMode(properties.totalsMode);
         setQuotaKey(properties.quotaKey);

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
@@ -2,77 +2,55 @@ package ru.yandex.clickhouse.settings;
 
 
 public enum ClickHouseQueryParam {
-    MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class),
+    MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class, "FIXME"),
     /**
-     * How to calculate TOTALS when HAVING is present, as well as when max_rows_to_group_by and group_by_overflow_mode = 'any' are present.
      * https://clickhouse.yandex/reference_en.html#WITH TOTALS modifier
      */
-    TOTALS_MODE("totals_mode", null, String.class),
+    TOTALS_MODE("totals_mode", null, String.class, "How to calculate TOTALS when HAVING is present, as well as when max_rows_to_group_by and group_by_overflow_mode = 'any' are present."),
+    QUOTA_KEY("quota_key", null, String.class, "quota is calculated for each quota_key value. For example here may be some user name."),
+    PRIORITY("priority", null, Integer.class, "The lower the value the bigger the priority."),
+    DATABASE("database", null, String.class, "database name used by default"),
+    COMPRESS("compress", true, Boolean.class, "whether to compress transferred data or not"),
     /**
-     * quota is calculated for each quota_key value.
-     * For example here may be some user name.
-     */
-    QUOTA_KEY("quota_key", null, String.class),
-    /**
-     * The lower the value the bigger the priority.
-     */
-    PRIORITY("priority", null, Integer.class),
-    /**
-     * database name used by default
-     */
-    DATABASE("database", null, String.class),
-    /**
-     *  whether to compress transfered data or not
-     */
-    COMPRESS("compress", true, Boolean.class),
-    /**
-     * Whether to include extreme values.
      * https://clickhouse.yandex/reference_en.html#Extreme values
      */
-    EXTREMES("extremes", false, String.class),
+    EXTREMES("extremes", false, Boolean.class, "Whether to include extreme values."),
     /**
-     * The maximum number of query processing threads
      * https://clickhouse.yandex/reference_en.html#max_threads
      */
-    MAX_THREADS("max_threads", null, Integer.class),
+    MAX_THREADS("max_threads", null, Integer.class, "The maximum number of query processing threads"),
     /**
-     * Maximum query execution time in seconds.
      * https://clickhouse.yandex/reference_en.html#max_execution_time
      */
-    MAX_EXECUTION_TIME("max_execution_time", null, Integer.class),
+    MAX_EXECUTION_TIME("max_execution_time", null, Integer.class, "Maximum query execution time in seconds."),
     /**
      * https://clickhouse.yandex/reference_en.html#max_block_size
      */
-    MAX_BLOCK_SIZE("max_block_size", null, Integer.class),
+    MAX_BLOCK_SIZE("max_block_size", null, Integer.class, "FIXME"),
 
     /**
-     * Maximum number of unique keys received from aggregation. This setting lets you limit memory consumption when aggregating.
      * https://clickhouse.yandex/reference_en.html#max_rows_to_group_by
      */
-    MAX_ROWS_TO_GROUP_BY("max_rows_to_group_by", null, Integer.class),
+    MAX_ROWS_TO_GROUP_BY("max_rows_to_group_by", null, Integer.class,
+            "Maximum number of unique keys received from aggregation. This setting lets you limit memory consumption when aggregating."),
 
     /**
      * https://clickhouse.yandex/reference_en.html#Settings profiles
      */
-    PROFILE("profile", null, String.class),
-    /**
-     *  user name, by default - default
-     */
-    USER("user", null, String.class),
-
-    /**
-     * user password, by default null
-     */
-    PASSWORD("password", null, String.class);
+    PROFILE("profile", null, String.class, "FIXME"),
+    USER("user", null, String.class, "user name, by default - default"),
+    PASSWORD("password", null, String.class, "user password, by default null");
 
     private final String key;
     private final Object defaultValue;
     private final Class clazz;
+    private final String description;
 
-    ClickHouseQueryParam(String key, Object defaultValue, Class clazz) {
+    ClickHouseQueryParam(String key, Object defaultValue, Class clazz, String description) {
         this.key = key;
         this.defaultValue = defaultValue;
         this.clazz = clazz;
+        this.description = description;
     }
 
     public String getKey() {
@@ -85,6 +63,10 @@ public enum ClickHouseQueryParam {
 
     public Class getClazz() {
         return clazz;
+    }
+
+    public String getDescription(){
+        return description;
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
@@ -5,7 +5,8 @@ import java.sql.DriverPropertyInfo;
 import java.util.Properties;
 
 public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
-    MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class, "FIXME"),
+    //dbms/include/DB/Interpreters/Settings.h
+    MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class, "max shard replica count "),
     /**
      * https://clickhouse.yandex/reference_en.html#WITH TOTALS modifier
      */
@@ -29,7 +30,7 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
     /**
      * https://clickhouse.yandex/reference_en.html#max_block_size
      */
-    MAX_BLOCK_SIZE("max_block_size", null, Integer.class, "FIXME"),
+    MAX_BLOCK_SIZE("max_block_size", null, Integer.class, "Recommendation for what size of block (in number of rows) to load from tables"),
 
     /**
      * https://clickhouse.yandex/reference_en.html#max_rows_to_group_by
@@ -40,7 +41,7 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
     /**
      * https://clickhouse.yandex/reference_en.html#Settings profiles
      */
-    PROFILE("profile", null, String.class, "FIXME"),
+    PROFILE("profile", null, String.class, "Settings profile: a collection of settings grouped under the same name"),
     USER("user", null, String.class, "user name, by default - default"),
     PASSWORD("password", null, String.class, "user password, by default null");
 
@@ -78,7 +79,7 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
     }
 
     public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
-        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, properties.getProperty(key));
+        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, driverPropertyValue(properties));
         propertyInfo.required = false;
         propertyInfo.description = description;
         propertyInfo.choices = driverPropertyInfoChoices();
@@ -87,5 +88,13 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
 
     private String[] driverPropertyInfoChoices() {
         return clazz == Boolean.class || clazz == Boolean.TYPE ? new String[]{"true", "false"} : null;
+    }
+
+    private String driverPropertyValue(Properties properties) {
+        String value = properties.getProperty(key);
+        if (value == null) {
+            value = defaultValue == null ? null : defaultValue.toString();
+        }
+        return value;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
@@ -4,7 +4,7 @@ package ru.yandex.clickhouse.settings;
 import java.sql.DriverPropertyInfo;
 import java.util.Properties;
 
-public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
+public enum ClickHouseQueryParam implements DriverPropertyCreator {
     //dbms/include/DB/Interpreters/Settings.h
     MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class, "max shard replica count "),
     /**
@@ -78,7 +78,7 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
         return name().toLowerCase();
     }
 
-    public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
+    public DriverPropertyInfo createDriverPropertyInfo(Properties properties) {
         DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, driverPropertyValue(properties));
         propertyInfo.required = false;
         propertyInfo.description = description;

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
@@ -1,7 +1,10 @@
 package ru.yandex.clickhouse.settings;
 
 
-public enum ClickHouseQueryParam {
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+
+public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
     MAX_PARALLEL_REPLICAS("max_parallel_replicas", null, Integer.class, "FIXME"),
     /**
      * https://clickhouse.yandex/reference_en.html#WITH TOTALS modifier
@@ -72,5 +75,13 @@ public enum ClickHouseQueryParam {
     @Override
     public String toString() {
         return name().toLowerCase();
+    }
+
+    public DriverPropertyInfo toDriverPropertyInfo(Properties properties) {
+        DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, properties.getProperty(key));
+        propertyInfo.required = false;
+        propertyInfo.description = description;
+        propertyInfo.choices = null;
+        return propertyInfo;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseQueryParam.java
@@ -81,7 +81,11 @@ public enum ClickHouseQueryParam implements DriverPropertyInfoAware{
         DriverPropertyInfo propertyInfo = new DriverPropertyInfo(key, properties.getProperty(key));
         propertyInfo.required = false;
         propertyInfo.description = description;
-        propertyInfo.choices = null;
+        propertyInfo.choices = driverPropertyInfoChoices();
         return propertyInfo;
+    }
+
+    private String[] driverPropertyInfoChoices() {
+        return clazz == Boolean.class || clazz == Boolean.TYPE ? new String[]{"true", "false"} : null;
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyCreator.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyCreator.java
@@ -1,0 +1,8 @@
+package ru.yandex.clickhouse.settings;
+
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+
+public interface DriverPropertyCreator {
+    DriverPropertyInfo createDriverPropertyInfo(Properties properties);
+}

--- a/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyInfoAware.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyInfoAware.java
@@ -1,0 +1,8 @@
+package ru.yandex.clickhouse.settings;
+
+import java.sql.DriverPropertyInfo;
+import java.util.Properties;
+
+public interface DriverPropertyInfoAware {
+    DriverPropertyInfo toDriverPropertyInfo(Properties properties);
+}

--- a/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyInfoAware.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/DriverPropertyInfoAware.java
@@ -1,8 +1,0 @@
-package ru.yandex.clickhouse.settings;
-
-import java.sql.DriverPropertyInfo;
-import java.util.Properties;
-
-public interface DriverPropertyInfoAware {
-    DriverPropertyInfo toDriverPropertyInfo(Properties properties);
-}

--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -14,8 +14,7 @@ public class TypeUtils {
 
     public static int toSqlType(String clickshouseType) {
         if (clickshouseType.startsWith("Int") || clickshouseType.startsWith("UInt")) {
-            if (clickshouseType.endsWith("64")) return Types.BIGINT;
-            else return Types.INTEGER;
+            return (clickshouseType.endsWith("64")) ? Types.BIGINT : Types.INTEGER;
         }
         if ("String".equals(clickshouseType)) return Types.VARCHAR;
         if (clickshouseType.startsWith("Float")) return Types.FLOAT;

--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -14,7 +14,7 @@ public class TypeUtils {
 
     public static int toSqlType(String clickshouseType) {
         if (clickshouseType.startsWith("Int") || clickshouseType.startsWith("UInt")) {
-            return (clickshouseType.endsWith("64")) ? Types.BIGINT : Types.INTEGER;
+            return clickshouseType.endsWith("64") ? Types.BIGINT : Types.INTEGER;
         }
         if ("String".equals(clickshouseType)) return Types.VARCHAR;
         if (clickshouseType.startsWith("Float")) return Types.FLOAT;

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -44,7 +44,6 @@ public class ClickHouseStatementTest {
         assertEquals(withCredentials.getUser(), "test_user");
         assertEquals(withCredentials.getPassword(), "test_password");
 
-        ClickHouseProperties props = ClickhouseJdbcUrlParser.parse("jdbc:clickhouse://localhost:1234/ppc", new Properties());
         ClickHouseStatementImpl statement = new ClickHouseStatementImpl(
                 HttpClientBuilder.create().build(),null, withCredentials
                 );

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -6,6 +6,7 @@ import org.testng.annotations.Test;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.Properties;
 
@@ -34,7 +35,7 @@ public class ClickHouseStatementTest {
     }
 
     @Test
-    public void testCredentials() throws SQLException {
+    public void testCredentials() throws SQLException, URISyntaxException {
         ClickHouseProperties properties = new ClickHouseProperties(new Properties());
         ClickHouseProperties withCredentials = properties.withCredentials("test_user", "test_password");
         assertTrue(withCredentials != properties);
@@ -43,11 +44,9 @@ public class ClickHouseStatementTest {
         assertEquals(withCredentials.getUser(), "test_user");
         assertEquals(withCredentials.getPassword(), "test_password");
 
+        ClickHouseProperties props = ClickhouseJdbcUrlParser.parse("jdbc:clickhouse://localhost:1234/ppc", new Properties());
         ClickHouseStatementImpl statement = new ClickHouseStatementImpl(
-                HttpClientBuilder.create().build(),
-                new ClickHouseDataSource("jdbc:clickhouse://localhost:1234/ppc"),
-                null,
-                withCredentials
+                HttpClientBuilder.create().build(),null, withCredentials
                 );
 
         URI uri = statement.buildRequestUri(false, null);

--- a/src/test/java/ru/yandex/clickhouse/integration/ArrayTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ArrayTest.java
@@ -31,7 +31,6 @@ public class ArrayTest {
     @BeforeTest
     public void setUp() throws Exception {
         ClickHouseProperties properties = new ClickHouseProperties();
-//        dataSource = new ClickHouseDataSource("jdbc:clickhouse://health-house-testing.market.yandex.net:8123/market", properties);
         dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123", properties);
         connection = dataSource.getConnection();
     }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -1,6 +1,7 @@
 package ru.yandex.clickhouse.integration;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import ru.yandex.clickhouse.ClickHouseArray;
@@ -23,6 +24,13 @@ public class ClickHousePreparedStatementTest {
         dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123", properties);
         connection = dataSource.getConnection();
         connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS test");
+    }
+
+    @AfterTest
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Test(enabled = false)

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
@@ -1,0 +1,43 @@
+package ru.yandex.clickhouse.integration;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import ru.yandex.clickhouse.ClickHouseDataSource;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
+public class ClickHouseStatementImplTest {
+    private ClickHouseDataSource dataSource;
+    private Connection connection;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        ClickHouseProperties properties = new ClickHouseProperties();
+        dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123", properties);
+        connection = dataSource.getConnection();
+    }
+
+    @AfterTest
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test(enabled = false)
+    public void testUpdateCountForSelect() throws Exception {
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT dummy FROM system.one");
+        Assert.assertEquals(stmt.getUpdateCount(), -1);
+        rs.next();
+        Assert.assertEquals(stmt.getUpdateCount(), -1);
+        rs.close();
+        stmt.close();
+    }
+}


### PR DESCRIPTION
1) Логика обработки jdbc url вынесена из ClickHouseDataSource в ClickhouseJdbcUrlParser (теперь не надо тащить DataSource в ConnectionImpl)
2) Реализован ClickHouseDriver.getPropertyInfo
3) ClickHouseDatabaseMetadata.getColumns переключен с 'desc table' на 'select from system.columns': теперь schemaPattern и tableNamePattern действительно работают. Как следствие jooq может генерировать java-классы для таблиц.
4) Исправлена проблема с зависанием DataGrip из https://github.com/yandex/clickhouse-jdbc/issues/21