### PR TITLE
Forcibly disable extremes when using ResultSet

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,6 +75,14 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     }
 
     public ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException {
+        // forcibly disable extremes for ResultSet queries
+        if (additionalDBParams == null) {
+            additionalDBParams = new HashMap<ClickHouseQueryParam, String>();
+        } else {
+            additionalDBParams = new HashMap<ClickHouseQueryParam, String>(additionalDBParams);
+        }
+        additionalDBParams.put(ClickHouseQueryParam.EXTREMES, "false");
+
         InputStream is = getInputStream(sql, additionalDBParams);
         try {
             if (isSelect(sql)) {

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
@@ -82,4 +82,25 @@ public class ClickHouseStatementImplTest {
         Assert.assertTrue(bigUInt64 instanceof BigInteger);
         Assert.assertEquals(bigUInt64, new BigInteger("18446744073709551606"));
     }
+
+    @Test
+    public void testResultSetWithExtremes() throws SQLException {
+        ClickHouseProperties properties = new ClickHouseProperties();
+        properties.setExtremes(true);
+        ClickHouseDataSource dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123", properties);
+        Connection connection = dataSource.getConnection();
+
+        try {
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery("select 1");
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1)).append("\n");
+            }
+
+            Assert.assertEquals(sb.toString(), "1\n");
+        } finally {
+            connection.close();
+        }
+    }
 }


### PR DESCRIPTION
When setting extremes = true in connection properties, and using methods that return ResultSet, then empty row and extremes row are returned, that is not expected.
Issue appeared after bf9de10
As a solution forcibly disable extremes when using methods that return ResultSet