### PR TITLE
Ability to send external data along with query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <version>4.5.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+        <dependency>
             <groupId>net.jpountz.lz4</groupId>
             <artifactId>lz4</artifactId>
             <version>1.3.0</version>

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseExternalData.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseExternalData.java
@@ -1,0 +1,89 @@
+package ru.yandex.clickhouse;
+
+import java.io.InputStream;
+
+/**
+ * @author zgmnkv
+ */
+public class ClickHouseExternalData {
+
+    private String name;
+    private InputStream content;
+    private String format;
+    private String types;
+    private String structure;
+
+    public ClickHouseExternalData() {
+    }
+
+    public ClickHouseExternalData(String name, InputStream content) {
+        this.name = name;
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public InputStream getContent() {
+        return content;
+    }
+
+    public void setContent(InputStream content) {
+        this.content = content;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getTypes() {
+        return types;
+    }
+
+    public void setTypes(String types) {
+        this.types = types;
+    }
+
+    public String getStructure() {
+        return structure;
+    }
+
+    public void setStructure(String structure) {
+        this.structure = structure;
+    }
+
+    public ClickHouseExternalData withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ClickHouseExternalData withContent(InputStream content) {
+        this.content = content;
+        return this;
+    }
+
+    public ClickHouseExternalData withFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public ClickHouseExternalData withTypes(String types) {
+        this.types = types;
+        return this;
+    }
+
+    public ClickHouseExternalData withStructure(String structure) {
+        this.structure = structure;
+        return this;
+    }
+
+}

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 import java.util.Map;
 
 
@@ -14,5 +15,6 @@ public interface ClickHouseStatement extends Statement {
     ClickHouseResponse executeQueryClickhouseResponse(String sql) throws SQLException;
     ClickHouseResponse executeQueryClickhouseResponse(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
     ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
+    ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, List<ClickHouseExternalData> externalData) throws SQLException;
     void sendStream(InputStream content, String table) throws SQLException;
 }

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -48,7 +48,7 @@ public class ClickHouseStatementTest {
                 HttpClientBuilder.create().build(),null, withCredentials
                 );
 
-        URI uri = statement.buildRequestUri(false, null);
+        URI uri = statement.buildRequestUri(null, null, null, false);
         String query = uri.getQuery();
         assertTrue(query.contains("password=test_password"));
         assertTrue(query.contains("user=test_user"));

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
@@ -13,6 +13,7 @@ import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;


### PR DESCRIPTION
Support of ClickHouse feature to send external data with query in a single http request.
[External data for query processing](https://clickhouse.yandex/reference_en.html#External%20data%20for%20query%20processing)