### PR TITLE
(fix) Use Properties#getProperty(..) instead of #get(..) which loses defaults

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
@@ -44,7 +44,7 @@ public class ClickhouseJdbcUrlParser {
         props.setPort(port);
         String database = uri.getPath();
         if (database == null || database.isEmpty()) {
-            String defaultsDb = (String)defaults.get(ClickHouseQueryParam.DATABASE.getKey());
+            String defaultsDb = defaults.getProperty(ClickHouseQueryParam.DATABASE.getKey());
             database = defaultsDb == null ? DEFAULT_DATABASE : defaultsDb;
         } else {
             Matcher m = DB_PATH_PATTERN.matcher(database);

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -219,16 +219,16 @@ public class ClickHouseProperties {
 
     @SuppressWarnings("unchecked")
     private <T> T getSetting(Properties info, String key, Object defaultValue, Class clazz){
-        Object val = info.get(key);
+        Object val = info.getProperty(key);
         if (val == null)
             return (T)defaultValue;
-        if ((clazz == int.class || clazz == Integer.class) && val instanceof String) {
+        if (clazz == int.class || clazz == Integer.class) {
             return (T) clazz.cast(Integer.valueOf((String) val));
         }
-        if ((clazz == long.class || clazz == Long.class) && val instanceof String) {
+        if (clazz == long.class || clazz == Long.class) {
             return (T) clazz.cast(Long.valueOf((String) val));
         }
-        if ((clazz == boolean.class || clazz == Boolean.class) && val instanceof String) {
+        if (clazz == boolean.class || clazz == Boolean.class) {
             return (T) clazz.cast(Boolean.valueOf((String) val));
         }
         return (T) clazz.cast(val);

--- a/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
+++ b/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
@@ -1,0 +1,27 @@
+package ru.yandex.clickhouse.settings;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClickHousePropertiesTest {
+
+    /**
+     * Method {@link ru.yandex.clickhouse.ClickhouseJdbcUrlParser#parseUriQueryPart(URI, Properties)} returns instance
+     * of {@link Properties} with defaults. These defaults may be missed if method
+     * {@link java.util.Hashtable#get(Object)} is used for {@code Properties}.
+     */
+    @Test
+    public void constructorShouldNotIgnoreDefaults() {
+        Properties defaults = new Properties();
+        String expectedUsername = "superuser";
+        defaults.setProperty("user", expectedUsername);
+        Properties propertiesWithDefaults = new Properties(defaults);
+
+        ClickHouseProperties clickHouseProperties = new ClickHouseProperties(propertiesWithDefaults);
+        Assert.assertEquals(clickHouseProperties.getUser(), expectedUsername);
+    }
+
+}


### PR DESCRIPTION
The issue behind this fix is about missing properties after in case when both Properties and urlProperties are set.
See also `ClickhouseJdbcUrlParser#parseUriQueryPart(..)` https://github.com/yandex/clickhouse-jdbc/blob/master/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java#L66