### PR TITLE
jdbc url query parameters are not propagated into HttpClientBuilder

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -41,7 +41,7 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-        ClickHouseHttpClientBuilder clientBuilder = new ClickHouseHttpClientBuilder(properties);
+        ClickHouseHttpClientBuilder clientBuilder = new ClickHouseHttpClientBuilder(this.properties);
         log.debug("new connection");
         httpclient = clientBuilder.buildClient();
     }


### PR DESCRIPTION
for example, if you specify connection_timeout in jdbc url, it won't be set for HttpClient