### PR TITLE
escape and unescape non IOS-8859-1 characters

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ByteFragment.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ByteFragment.java
@@ -175,12 +175,16 @@ public class ByteFragment {
 
     public static void escape(byte[] bytes, OutputStream stream) throws IOException {
         for (byte b : bytes) {
-            byte converted = reverse[b];
-            if (converted != -1) {
-                stream.write(92);
-                stream.write(converted);
-            } else {
+            if(b < 0 || b >= reverse.length) {
                 stream.write(b);
+            } else {
+                byte converted = reverse[b];
+                if (converted != -1) {
+                    stream.write(92);
+                    stream.write(converted);
+                } else {
+                    stream.write(b);
+                }
             }
         }
     }

--- a/src/test/java/ru/yandex/clickhouse/response/ByteFragmentTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ByteFragmentTest.java
@@ -1,0 +1,38 @@
+package ru.yandex.clickhouse.response;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class ByteFragmentTest {
+
+    @DataProvider(name = "stringEscape")
+    public Object[][] stringEscape() {
+        return new Object[][]{
+                {"abc'xyz", "abc\\'xyz"},
+                {"\rabc\n\0xyz\b\f\txyz\\", "\\rabc\\n\\Nxyz\\b\\f\\txyz\\\\"},
+                {"\n汉字'", "\\n汉字\\'"},
+                {"юникод,'юникод'\n", "юникод,\\'юникод\\'\\n"}
+        };
+    }
+
+    @Test(dataProvider = "stringEscape")
+    public void testEscape(String str, String escapedStr) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteFragment.escape(str.getBytes("UTF-8"), out);
+        assertEquals(out.toString("UTF-8"), escapedStr);
+    }
+
+    @Test(dataProvider = "stringEscape")
+    public void testUnescape(String str, String escapedStr) throws IOException {
+        byte[] bytes = escapedStr.getBytes("UTF-8");
+        ByteFragment byteFragment = new ByteFragment(bytes,0, bytes.length);
+        assertEquals(new String(byteFragment.unescape()), str);
+    }
+
+}


### PR DESCRIPTION
Although this PR add supporting of  escaping and unescaping IOS-8859-1 characters, the escaping and unescaping should be based on Characters instead of Bytes. I think it should be improved in future.