### PR TITLE
Allow to set boolean params as 0/1

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -227,17 +227,23 @@ public class ClickHouseProperties {
 
     @SuppressWarnings("unchecked")
     private <T> T getSetting(Properties info, String key, Object defaultValue, Class clazz){
-        Object val = info.getProperty(key);
+        String val = info.getProperty(key);
         if (val == null)
             return (T)defaultValue;
         if (clazz == int.class || clazz == Integer.class) {
-            return (T) clazz.cast(Integer.valueOf((String) val));
+            return (T) clazz.cast(Integer.valueOf(val));
         }
         if (clazz == long.class || clazz == Long.class) {
-            return (T) clazz.cast(Long.valueOf((String) val));
+            return (T) clazz.cast(Long.valueOf(val));
         }
         if (clazz == boolean.class || clazz == Boolean.class) {
-            return (T) clazz.cast(Boolean.valueOf((String) val));
+            final Boolean boolValue;
+            if ("1".equals(val) || "0".equals(val)) {
+                boolValue = "1".equals(val);
+            } else {
+                boolValue = Boolean.valueOf(val);
+            }
+            return (T) clazz.cast(boolValue);
         }
         return (T) clazz.cast(val);
     }

--- a/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
+++ b/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
@@ -63,7 +63,8 @@ public class ClickHousePropertiesTest {
         Assert.assertTrue(new ClickHouseProperties().isCompress());
         Assert.assertFalse(new ClickHouseProperties(new Properties(){{setProperty("compress", "0");}}).isCompress());
         Assert.assertTrue(new ClickHouseProperties(new Properties(){{setProperty("compress", "1");}}).isCompress());
-
+    }
+    
     @Test
     public void clickHouseQueryParamContainsMaxMemoryUsage() throws Exception {
         final ClickHouseProperties clickHouseProperties = new ClickHouseProperties();

--- a/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
+++ b/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
@@ -1,11 +1,11 @@
 package ru.yandex.clickhouse.settings;
 
-import java.net.URI;
-import java.util.Properties;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import ru.yandex.clickhouse.ClickHouseDataSource;
+
+import java.net.URI;
+import java.util.Properties;
 
 public class ClickHousePropertiesTest {
 
@@ -56,5 +56,12 @@ public class ClickHousePropertiesTest {
                 clickHouseDataSource.getProperties().getTotalsMode(),
                 ClickHouseQueryParam.TOTALS_MODE.getDefaultValue()
         );
+    }
+
+    @Test
+    public void booleanParamCanBeParsedAsZeroAndOne() throws Exception {
+        Assert.assertTrue(new ClickHouseProperties().isCompress());
+        Assert.assertFalse(new ClickHouseProperties(new Properties(){{setProperty("compress", "0");}}).isCompress());
+        Assert.assertTrue(new ClickHouseProperties(new Properties(){{setProperty("compress", "1");}}).isCompress());
     }
 }


### PR DESCRIPTION
In documentation bool params have 0/1 values but in Java I should keep in mind that they need to be replaced with false/true values.
This patch allows using 0/1 in boolean params and correctly parse them.