### PR TITLE
Fixed that Clickhouse is looking for \N for NULL values, not "NULL".

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -164,7 +164,7 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        setBind(parameterIndex, "NULL");
+        setBind(parameterIndex, "\N");
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -164,7 +164,7 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        setBind(parameterIndex, "\N");
+        setBind(parameterIndex, "\\N");
     }
 
     @Override

--- a/src/test/java/ru/yandex/clickhouse/integration/BatchInserts.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/BatchInserts.java
@@ -15,7 +15,7 @@ public class BatchInserts {
     @BeforeTest
     public void setUp() throws Exception {
         ClickHouseProperties properties = new ClickHouseProperties();
-        dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123", properties);
+        dataSource = new ClickHouseDataSource("jdbc:clickhouse://localhost:9123", properties);
         connection = dataSource.getConnection();
         connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS test");
     }
@@ -133,5 +133,44 @@ public class BatchInserts {
         Assert.assertEquals(rs.getDouble("float64"), float64);
 
         Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void batchInsertNulls() throws Exception {
+        connection.createStatement().execute("DROP TABLE IF EXISTS test.batch_insert_nulls");
+        connection.createStatement().execute(
+                "CREATE TABLE test.batch_insert_nulls (" +
+                        "date Date," +
+                        "date_time Nullable(DateTime)," +
+                        "string Nullable(String)," +
+                        "int32 Nullable(Int32)," +
+                        "float64 Nullable(Float64)" +
+                        ") ENGINE = MergeTree(date, (date), 8192)"
+        );
+
+        PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO test.batch_insert_nulls (date, date_time, string, int32, float64) VALUES (?, ?, ?, ?, ?)"
+        );
+
+        Date date = new Date(602110800000L); //1989-01-30
+        statement.setDate(1, date);
+        statement.setObject(2, null, Types.TIMESTAMP);
+        statement.setObject(3, null, Types.VARCHAR);
+        statement.setObject(4, null, Types.INTEGER);
+        statement.setObject(5, null, Types.DOUBLE);
+        statement.addBatch();
+        statement.executeBatch();
+
+        ResultSet rs = connection.createStatement().executeQuery("SELECT date, date_time, string, int32, float64 from test.batch_insert_nulls");
+        Assert.assertTrue(rs.next());
+
+        Assert.assertEquals(rs.getDate("date"), date);
+        Assert.assertNull(rs.getTimestamp("date_time"));
+        Assert.assertNull(rs.getString("string"));
+        Assert.assertNull(rs.getInt("int32"));
+        Assert.assertNull(rs.getDouble("float64"));
+
+        Assert.assertFalse(rs.next());
+        connection.createStatement().execute("DROP TABLE test.batch_insert_nulls");
     }
 }


### PR DESCRIPTION
#89 With maven dependency:
```
2017-04-15 19:58:19.461 ERROR 13323 --- [       batch_-1] o.s.batch.core.step.AbstractStep         : Encountered an error executing step read_write in job csvToCh_/tmp/dataset4435816889860106240.csv

\��2�Q��y�2���   �   �aCode: 27, e.displayText() = DB::Exception: Cannot parse NaN.: (at row 1)
Could not print diagnostic info because? �ing of data hasn't started.
  ${, e.wha� Ption

	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:58)
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:28)
	at ru.yandex.clickhouse.ClickHouseStatementImpl.sendStream(ClickHouseStatementImpl.java:637)
	at ru.yandex.clickhouse.ClickHousePreparedStatementImpl.executeBatch(ClickHousePreparedStatementImpl.java:342)
         ...
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
\��2�Q��y�2���   �   �aCode: 27, e.displayText() = DB::Exception: Cannot parse NaN.: (at row 1)
Could not print diagnostic info because? �ing of data hasn't started.
  ${, e.wha� Ption

	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:53)
	... 25 common frames omitted
```
JDBC writes empty like null and we get this error.

Referred topic in clickhouse - https://github.com/yandex/ClickHouse/issues/700

After correction all is fine.

UPD 
Ups, I corrected it in your branch originally and hurry. ;)