### PR TITLE
Change default connection timeout 50ms -> 10s

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -10,7 +10,7 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
     BUFFER_SIZE("buffer_size", 65536, ""),
     APACHE_BUFFER_SIZE("apache_buffer_size", 65536, ""),
     SOCKET_TIMEOUT("socket_timeout", 30000, ""),
-    CONNECTION_TIMEOUT("connection_timeout", 50, ""),
+    CONNECTION_TIMEOUT("connection_timeout", 10 * 1000, "connection timeout in milliseconds"),
     SSL("ssl", false, "enable SSL/TLS for the connection"),
     SSL_ROOT_CERTIFICATE("sslrootcert", "", "SSL/TLS root certificate"),
     SSL_MODE("sslmode", "strict", "verify or not certificate: none (don't verify), strict (verify)"),


### PR DESCRIPTION
50ms too small for most environments,
10s - default connection timeout in Clickhouse core
https://github.com/yandex/ClickHouse/blob/8e5f92f02538d11151dac0aa45a75fdfb677a11c/dbms/src/Core/Defines.h#L11