### PR TITLE
#117 translate sql double quotes to back quotes

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -372,8 +372,12 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     }
 
     static String clickhousifySql(String sql) {
-
+        sql = translateDoubleQuotesToBackQuotes(sql);
         return addFormatIfAbsent(sql, "TabSeparatedWithNamesAndTypes");
+    }
+
+    static String translateDoubleQuotesToBackQuotes(String sql) {
+        return sql.replaceAll("\"([\\w\\s-]+)\"", "`$1`");
     }
 
     /**


### PR DESCRIPTION
Spark adds double quotes to column names when executing a sql query, which is not currently supported in the clickhouse jdbc.

Sql string double quotes get replaced with back quotes, in the clickhousifySql function, e.g.:
```
"a", "a b", "a 1 b-c_d"
``` 
translates to 
```
`a`, `a b`, `a 1 b-c_d`
```