### PR TITLE
fix date parsing timezone

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -50,7 +50,9 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     private void initTimeZone(TimeZone timeZone) {
         dateTimeFormat.setTimeZone(timeZone);
-        dateFormat.setTimeZone(timeZone);
+        if (properties.isUseServerTimeZoneForDates()) {
+            dateFormat.setTimeZone(timeZone);
+        }
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -618,7 +618,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     @Override
     public void sendRowBinaryStream(String sql, ClickHouseStreamCallback callback) throws SQLException {
         sendStream(
-            new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone()), sql, ClickHouseFormat.RowBinary
+            new ClickHouseStreamHttpEntity(callback), sql, ClickHouseFormat.RowBinary
         );
     }
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -107,7 +107,8 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
                     extractDBName(sql),
                     extractTableName(sql),
                     this,
-                    ((ClickHouseConnection) getConnection()).getTimeZone()
+                    ((ClickHouseConnection) getConnection()).getTimeZone(),
+                    properties
                 );
                 currentResult.setMaxRows(maxRows);
                 return currentResult;

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -618,7 +618,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     @Override
     public void sendRowBinaryStream(String sql, ClickHouseStreamCallback callback) throws SQLException {
         sendStream(
-            new ClickHouseStreamHttpEntity(callback), sql, ClickHouseFormat.RowBinary
+            new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone(), properties), sql, ClickHouseFormat.RowBinary
         );
     }
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -52,7 +52,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
 
     private final CloseableHttpClient client;
 
-    private ClickHouseProperties properties = new ClickHouseProperties();
+    protected ClickHouseProperties properties = new ClickHouseProperties();
 
     private ClickHouseConnection connection;
 

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
@@ -1,5 +1,6 @@
 package ru.yandex.clickhouse.response;
 
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.util.guava.StreamUtils;
 
 import java.io.ByteArrayInputStream;
@@ -20,6 +21,7 @@ public class ClickHouseResultBuilder {
     private List<String> types;
     private List<List<?>> rows = new ArrayList<List<?>>();
     private TimeZone timezone = TimeZone.getTimeZone("UTC");
+    private ClickHouseProperties properties = new ClickHouseProperties();
 
     public static ClickHouseResultBuilder builder(int columnsNum) {
         return new ClickHouseResultBuilder(columnsNum);
@@ -64,6 +66,11 @@ public class ClickHouseResultBuilder {
         return this;
     }
 
+    public ClickHouseResultBuilder properties(ClickHouseProperties properties) {
+        this.properties = properties;
+        return this;
+    }
+
     public ClickHouseResultSet build() {
         try {
             if (names == null) throw new IllegalStateException("names == null");
@@ -78,7 +85,7 @@ public class ClickHouseResultBuilder {
             byte[] bytes = baos.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
-            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown", null, timezone);
+            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown", null, timezone, properties);
         } catch (IOException e) {
             throw new RuntimeException("Never happens", e);
         }

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -79,7 +79,6 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     private void initTimeZone(TimeZone timeZone) {
         sdf.setTimeZone(timeZone);
-        dateFormat.setTimeZone(timeZone);
     }
 
     private static String[] toStringArray(ByteFragment headerFragment) {

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -3,6 +3,7 @@ package ru.yandex.clickhouse.response;
 import ru.yandex.clickhouse.ClickHouseArray;
 import ru.yandex.clickhouse.ClickHouseStatement;
 import ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.util.TypeUtils;
 
 import java.io.IOException;
@@ -47,12 +48,15 @@ public class ClickHouseResultSet extends AbstractResultSet {
     private int rowNumber;
 
     // statement result set belongs to
-    private Statement statement;
+    private ClickHouseStatement statement;
 
-    public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table, ClickHouseStatement statement, TimeZone timezone) throws IOException {
+    private final ClickHouseProperties properties;
+
+    public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
         this.db = db;
         this.table = table;
         this.statement = statement;
+        this.properties = properties;
         initTimeZone(timezone);
         bis = new StreamSplitter(is, (byte) 0x0A, bufferSize);  ///   \n
         ByteFragment headerFragment = bis.next();
@@ -79,6 +83,9 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     private void initTimeZone(TimeZone timeZone) {
         sdf.setTimeZone(timeZone);
+        if (properties.isUseServerTimeZoneForDates()) {
+            dateFormat.setTimeZone(timeZone);
+        }
     }
 
     private static String[] toStringArray(ByteFragment headerFragment) {

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -38,7 +38,11 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
     MAX_COMPRESS_BUFFER_SIZE("maxCompressBufferSize", 1024*1024, ""),
 
     USE_SERVER_TIME_ZONE("use_server_time_zone", true, "Whether to use timezone from server. On connection init select timezone() will be executed"),
-    USE_TIME_ZONE("use_time_zone", "", "Which time zone to use")
+    USE_TIME_ZONE("use_time_zone", "", "Which time zone to use"),
+    USE_SERVER_TIME_ZONE_FOR_DATES("use_server_time_zone_for_dates", false,
+            "Whether to use timezone from server on Date parsing in getDate(). " +
+                    "If false, Date returned is a wrapper of a timestamp at start of the day in client timezone. " +
+                    "If true - at start of the day in server or use_timezone timezone.")
     ;
 
     private final String key;

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -32,7 +32,7 @@ public class ClickHouseProperties {
 
     private boolean useServerTimeZone;
     private String useTimeZone;
-
+    private boolean useServerTimeZoneForDates;
 
     // queries settings
     private Integer maxParallelReplicas;
@@ -79,6 +79,7 @@ public class ClickHouseProperties {
         this.sslMode = (String) getSetting(info, ClickHouseConnectionSettings.SSL_MODE);
         this.useServerTimeZone = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE);
         this.useTimeZone = (String)getSetting(info, ClickHouseConnectionSettings.USE_TIME_ZONE);
+        this.useServerTimeZoneForDates = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES);
 
         this.maxParallelReplicas = getSetting(info, ClickHouseQueryParam.MAX_PARALLEL_REPLICAS);
         this.totalsMode = getSetting(info, ClickHouseQueryParam.TOTALS_MODE);
@@ -121,6 +122,7 @@ public class ClickHouseProperties {
         ret.put(ClickHouseConnectionSettings.SSL_MODE.getKey(), String.valueOf(sslMode));
         ret.put(ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE.getKey(), String.valueOf(useServerTimeZone));
         ret.put(ClickHouseConnectionSettings.USE_TIME_ZONE.getKey(), String.valueOf(useTimeZone));
+        ret.put(ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES.getKey(), String.valueOf(useServerTimeZoneForDates));
 
         ret.put(ClickHouseQueryParam.MAX_PARALLEL_REPLICAS.getKey(), maxParallelReplicas);
         ret.put(ClickHouseQueryParam.TOTALS_MODE.getKey(), totalsMode);
@@ -165,6 +167,7 @@ public class ClickHouseProperties {
         setSslMode(properties.sslMode);
         setUseServerTimeZone(properties.useServerTimeZone);
         setUseTimeZone(properties.useTimeZone);
+        setUseServerTimeZoneForDates(properties.useServerTimeZoneForDates);
 
         setMaxParallelReplicas(properties.maxParallelReplicas);
         setTotalsMode(properties.totalsMode);
@@ -455,6 +458,14 @@ public class ClickHouseProperties {
 
     public void setUseTimeZone(String useTimeZone) {
         this.useTimeZone = useTimeZone;
+    }
+
+    public boolean isUseServerTimeZoneForDates() {
+        return useServerTimeZoneForDates;
+    }
+
+    public void setUseServerTimeZoneForDates(boolean useServerTimeZoneForDates) {
+        this.useServerTimeZoneForDates = useServerTimeZoneForDates;
     }
 
     public Integer getMaxParallelReplicas() {

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
@@ -3,14 +3,12 @@ package ru.yandex.clickhouse.util;
 import com.google.common.base.Preconditions;
 import com.google.common.io.LittleEndianDataOutputStream;
 import com.google.common.primitives.UnsignedLong;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Date;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,13 +21,11 @@ public class ClickHouseRowBinaryStream {
     private static final long U_INT32_MAX = (1L << 32) - 1;
 
     private final LittleEndianDataOutputStream out;
-    private final DateTimeZone dateTimeZone;
     private final LocalDate epochDate;
 
-    public ClickHouseRowBinaryStream(OutputStream outputStream, TimeZone timeZone) {
+    public ClickHouseRowBinaryStream(OutputStream outputStream) {
         this.out = new LittleEndianDataOutputStream(outputStream);
-        this.dateTimeZone = DateTimeZone.forTimeZone(timeZone);
-        this.epochDate = new LocalDate(0, dateTimeZone);
+        this.epochDate = new LocalDate(0);
     }
 
     public void writeUnsignedLeb128(int value) throws IOException {
@@ -130,7 +126,7 @@ public class ClickHouseRowBinaryStream {
 
     public void writeDate(Date date) throws IOException {
         Preconditions.checkNotNull(date);
-        LocalDate localDate = new LocalDate(date.getTime(), dateTimeZone);
+        LocalDate localDate = new LocalDate(date.getTime());
         int daysSinceEpoch = Days.daysBetween(epochDate, localDate).getDays();
         writeUInt16(daysSinceEpoch);
     }

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseStreamHttpEntity.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseStreamHttpEntity.java
@@ -6,7 +6,6 @@ import org.apache.http.entity.AbstractHttpEntity;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.TimeZone;
 
 /**
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
@@ -14,11 +13,9 @@ import java.util.TimeZone;
 public class ClickHouseStreamHttpEntity extends AbstractHttpEntity {
 
     private final ClickHouseStreamCallback callback;
-    private final TimeZone timeZone;
 
-    public ClickHouseStreamHttpEntity(ClickHouseStreamCallback callback, TimeZone timeZone) {
+    public ClickHouseStreamHttpEntity(ClickHouseStreamCallback callback) {
         Preconditions.checkNotNull(callback);
-        this.timeZone = timeZone;
         this.callback = callback;
     }
 
@@ -39,7 +36,7 @@ public class ClickHouseStreamHttpEntity extends AbstractHttpEntity {
 
     @Override
     public void writeTo(OutputStream out) throws IOException {
-        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(out, timeZone);
+        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(out);
         callback.writeTo(stream);
     }
 

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseStreamHttpEntity.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseStreamHttpEntity.java
@@ -2,10 +2,12 @@ package ru.yandex.clickhouse.util;
 
 import com.google.common.base.Preconditions;
 import org.apache.http.entity.AbstractHttpEntity;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.TimeZone;
 
 /**
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
@@ -13,10 +15,14 @@ import java.io.OutputStream;
 public class ClickHouseStreamHttpEntity extends AbstractHttpEntity {
 
     private final ClickHouseStreamCallback callback;
+    private final TimeZone timeZone;
+    private final ClickHouseProperties properties;
 
-    public ClickHouseStreamHttpEntity(ClickHouseStreamCallback callback) {
+    public ClickHouseStreamHttpEntity(ClickHouseStreamCallback callback, TimeZone timeZone, ClickHouseProperties properties) {
         Preconditions.checkNotNull(callback);
+        this.timeZone = timeZone;
         this.callback = callback;
+        this.properties = properties;
     }
 
     @Override
@@ -36,7 +42,7 @@ public class ClickHouseStreamHttpEntity extends AbstractHttpEntity {
 
     @Override
     public void writeTo(OutputStream out) throws IOException {
-        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(out);
+        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(out, timeZone, properties);
         callback.writeTo(stream);
     }
 

--- a/src/test/java/ru/yandex/clickhouse/integration/TimeZoneTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/TimeZoneTest.java
@@ -67,4 +67,18 @@ public class TimeZoneTest {
         rsMan.next();
         Assert.assertEquals(rsMan.getTime(2).getTime(), currentTime);
     }
+
+    @Test
+    public void dateTest() throws SQLException {
+        ResultSet rsMan = connectionManualTz.createStatement().executeQuery("select toDate('2017-07-05')");
+        ResultSet rsSrv = connectionServerTz.createStatement().executeQuery("select toDate('2017-07-05')");
+        rsMan.next();
+        rsSrv.next();
+        // check it doesn't depend on server timezone
+        Assert.assertEquals(rsMan.getDate(1), rsSrv.getDate(1));
+
+        // check it is start of correct day in client timezone
+        Assert.assertEquals(rsMan.getDate(1), new Date(117, 6, 5));
+
+    }
 }

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
@@ -6,7 +6,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.util.TimeZone;
 
 /**
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
@@ -182,7 +181,7 @@ public class ClickHouseRowBinaryStreamTest {
 
     private void check(StreamWriter streamWriter, byte[] expected) throws Exception {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(byteArrayOutputStream, TimeZone.getTimeZone("ETC"));
+        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(byteArrayOutputStream);
         streamWriter.write(stream);
         Assert.assertEquals(byteArrayOutputStream.toByteArray(), expected);
     }

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
@@ -4,8 +4,10 @@ import com.google.common.primitives.UnsignedLong;
 import org.joda.time.LocalDate;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import java.io.ByteArrayOutputStream;
+import java.util.TimeZone;
 
 /**
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
@@ -181,7 +183,7 @@ public class ClickHouseRowBinaryStreamTest {
 
     private void check(StreamWriter streamWriter, byte[] expected) throws Exception {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(byteArrayOutputStream);
+        ClickHouseRowBinaryStream stream = new ClickHouseRowBinaryStream(byteArrayOutputStream, TimeZone.getTimeZone("ETC"), new ClickHouseProperties());
         streamWriter.write(stream);
         Assert.assertEquals(byteArrayOutputStream.toByteArray(), expected);
     }


### PR DESCRIPTION
getDate must not depend on timezone, so it must return Date wrapper of timestamp at start of the day in client timezone.