### PR TITLE
Fix `ClickHousePreparedStatement.setObject(int, List<?>)` for Number

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -309,9 +309,9 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
             } else if (x instanceof BigInteger) {
                 setBind(parameterIndex, x.toString());
             } else if (x instanceof Collection) {
-                setBind(parameterIndex, ClickHouseArrayUtil.toString((Collection) x));
+                setArray(parameterIndex, (Collection) x);
             } else if (x.getClass().isArray()) {
-                setBind(parameterIndex, ClickHouseArrayUtil.arrayToString(x));
+                setArray(parameterIndex, (Object[]) x);
             } else {
                 throw new SQLDataException("Can't bind object of class " + x.getClass().getCanonicalName());
             }

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
@@ -46,7 +46,7 @@ public class ClickHouseArrayUtil {
     public static String toString(int[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (int value : values) {
-            builder.append(Integer.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -54,7 +54,7 @@ public class ClickHouseArrayUtil {
     public static String toString(long[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (long value : values) {
-            builder.append(Long.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -62,7 +62,7 @@ public class ClickHouseArrayUtil {
     public static String toString(float[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (float value : values) {
-            builder.append(Float.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -70,7 +70,7 @@ public class ClickHouseArrayUtil {
     public static String toString(double[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (double value : values) {
-            builder.append(Double.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -78,7 +78,7 @@ public class ClickHouseArrayUtil {
     public static String toString(byte[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (byte value : values) {
-            builder.append(Byte.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -86,7 +86,7 @@ public class ClickHouseArrayUtil {
     public static String toString(short[] values) {
         ArrayBuilder builder = new ArrayBuilder(false);
         for (short value : values) {
-            builder.append(Short.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -95,7 +95,7 @@ public class ClickHouseArrayUtil {
     public static String toString(char[] values) {
         ArrayBuilder builder = new ArrayBuilder(true);
         for (char value : values) {
-            builder.append(Character.toString(value));
+            builder.append(value);
         }
         return builder.build();
     }
@@ -104,7 +104,7 @@ public class ClickHouseArrayUtil {
     public static String toString(Object[] values) {
         ArrayBuilder builder = new ArrayBuilder(needQuote(values));
         for (Object value : values) {
-            builder.append(value.toString());
+            builder.append(value);
         }
         return builder.build();
     }
@@ -114,7 +114,7 @@ public class ClickHouseArrayUtil {
     }
 
     private static boolean needQuote(Object[] objects) {
-        return !Number.class.isAssignableFrom(objects.getClass().getComponentType());
+        return objects.length == 0 || !(objects[0] instanceof Number);
     }
 
     private static class ArrayBuilder {
@@ -128,9 +128,10 @@ public class ClickHouseArrayUtil {
             builder.append('[');
         }
 
-        private ArrayBuilder append(String value) {
+        private ArrayBuilder append(Object value) {
+            String serializedValue = value.toString();
             if (quote) {
-                value = ClickHouseUtil.escape(value);
+                serializedValue = ClickHouseUtil.escape(serializedValue);
             }
 
             if (built) {
@@ -142,7 +143,7 @@ public class ClickHouseArrayUtil {
             if (quote) {
                 builder.append('\'');
             }
-            builder.append(value);
+            builder.append(serializedValue);
             if (quote) {
                 builder.append('\'');
             }

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
@@ -1,5 +1,8 @@
 package ru.yandex.clickhouse.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,9 +33,46 @@ public class ClickHouseArrayUtilTest {
         );
 
         Assert.assertEquals(
+                ClickHouseArrayUtil.arrayToString(new double[]{0.1, 1.2}),
+                "[0.1,1.2]"
+        );
+
+        Assert.assertEquals(
             ClickHouseArrayUtil.arrayToString(new char[]{'a', 'b'}),
             "['a','b']"
         );
     }
 
+    @Test
+    public void testCollectionToString() throws Exception {
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", "b"))),
+                "['a','b']"
+        );
+
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", "'b\t"))),
+                "['a','\\'b\\t']"
+        );
+
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, 42))),
+                "[21,42]"
+        );
+
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, 42))),
+                "[21,42]"
+        );
+
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(0.1, 1.2))),
+                "[0.1,1.2]"
+        );
+
+        Assert.assertEquals(
+                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList('a', 'b'))),
+                "['a','b']"
+        );
+    }
 }


### PR DESCRIPTION
Imagine function:
```java
void mapObject(PreparedStatement statement, List<Supplier<?>> getters) {
    int count = 0;
    for (Supplier<?> getter : getters) {
        statement.setObject(++count, getter.get());
    }
}
```

It works for any types except numeric arrays. Array of double will be serialized as `['1.23','4.56']`, but clickhouse expects no quoting of number (`[1.23,4.56]`).