### PR TITLE
#123 & #134: handle null string values for bind parameters.

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -108,11 +108,11 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     private void appendBoundValue(StringBuilder sb, int num) {
         if (valuesQuote[num]) {
-            sb.append("'");
-        }
-        sb.append(binds[num]);
-        if (valuesQuote[num]) {
-            sb.append("'");
+            sb.append("'").append(binds[num]).append("'");
+        } else if (binds[num].equals("\\N")) {
+            sb.append("null");
+        } else {
+            sb.append(binds[num]);
         }
     }
 
@@ -211,7 +211,7 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     @Override
     public void setString(int parameterIndex, String x) throws SQLException {
-        setBind(parameterIndex, ClickHouseUtil.escape(x), true);
+        setBind(parameterIndex, ClickHouseUtil.escape(x), x != null);
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseUtil.java
@@ -21,7 +21,7 @@ public class ClickHouseUtil {
 
     public static String escape(String s) {
         if (s == null) {
-            return "NULL";
+            return "\\N";
         }
         return CLICKHOUSE_ESCAPER.escape(s);
     }

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseUtilTest.java
@@ -11,7 +11,7 @@ public class ClickHouseUtilTest {
 
     @Test
     public void testQuote() throws Exception {
-        assertEquals("NULL", ClickHouseUtil.escape(null));
+        assertEquals("\\N", ClickHouseUtil.escape(null));
         assertEquals("test", ClickHouseUtil.escape("test"));
         assertEquals("t\\n\\0\\r\\test\\'", ClickHouseUtil.escape("t\n\0\r\test'"));
     }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -76,4 +76,38 @@ public class ClickHousePreparedStatementTest {
         Assert.assertTrue(bigUInt64 instanceof BigInteger);
         Assert.assertEquals(bigUInt64, new BigInteger("18446744073709551606"));
     }
+
+    @Test
+    public void testInsertNullString() throws SQLException {
+        connection.createStatement().execute("DROP TABLE IF EXISTS test.null_insert");
+        connection.createStatement().execute(
+                "CREATE TABLE IF NOT EXISTS test.null_insert (val Nullable(String)) ENGINE = TinyLog"
+        );
+
+        PreparedStatement stmt = connection.prepareStatement("insert into test.null_insert (val) values (?)");
+        stmt.setNull(1, Types.VARCHAR);
+        stmt.execute();
+        stmt.setNull(1, Types.VARCHAR);
+        stmt.addBatch();
+        stmt.executeBatch();
+
+        stmt.setString(1, null);
+        stmt.execute();
+        stmt.setString(1, null);
+        stmt.addBatch();
+        stmt.executeBatch();
+
+        stmt.setObject(1, null);
+        stmt.execute();
+        stmt.setObject(1, null);
+        stmt.addBatch();
+        stmt.executeBatch();
+
+        Statement select = connection.createStatement();
+        ResultSet rs = select.executeQuery("select count(*), val from test.null_insert group by val");
+        rs.next();
+        Assert.assertEquals(rs.getInt(1), 6);
+        Assert.assertNull(rs.getString(2));
+        Assert.assertFalse(rs.next());
+    }
 }


### PR DESCRIPTION
There are two changes here:

* setString() adds an actual null value (\N) instead of the literal string 'NULL' when given a null parameter (fixes #123);
* A special case for null values is added to appendBoundValue (fixes #134).
