### PR TITLE
Add position of missing placeholder in PreparedStatement

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -117,9 +117,11 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
     }
 
     private static void checkBinded(String[] binds) throws SQLException {
+        int i = 0;
         for (String b : binds) {
+            ++i;
             if (b == null) {
-                throw new SQLException("Not all parameters binded");
+                throw new SQLException("Not all parameters binded (placeholder " + i + " is undefined)");
             }
         }
     }


### PR DESCRIPTION
**Goal**
Simplifying debugging process

**Current situation** 
When debugging bind issues, a debugger is needed for determining, what was missed

**Solution**
Added index of missing placeholder for PreparedStatement in exception message