### PR TITLE
Fix the URL pattern in the BalancedClickHouseDataSource class so that…

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
@@ -29,7 +29,7 @@ import static ru.yandex.clickhouse.ClickhouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFI
  */
 public class BalancedClickhouseDataSource implements DataSource {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(BalancedClickhouseDataSource.class);
-    private static final Pattern URL_TEMPLATE = Pattern.compile(JDBC_CLICKHOUSE_PREFIX + "//([a-zA-Z0-9_:,.]+)(/[a-zA-Z0-9_]+)?");
+    private static final Pattern URL_TEMPLATE = Pattern.compile(JDBC_CLICKHOUSE_PREFIX + "//([a-zA-Z0-9_:,.-]+)(/[a-zA-Z0-9_]+)?");
 
     private PrintWriter printWriter;
     private int loginTimeoutSeconds = 0;

--- a/src/test/java/ru/yandex/clickhouse/BalancedClickhouseDataSourceTest.java
+++ b/src/test/java/ru/yandex/clickhouse/BalancedClickhouseDataSourceTest.java
@@ -32,6 +32,21 @@ public class BalancedClickhouseDataSourceTest {
     }
 
 
+    @Test
+    public void testUrlSplitValidHostName() throws Exception {
+        assertEquals(Arrays.asList("jdbc:clickhouse://localhost:1234", "jdbc:clickhouse://_0another-host.com:4321"),
+                BalancedClickhouseDataSource.splitUrl("jdbc:clickhouse://localhost:1234,_0another-host.com:4321"));
+
+    }
+
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUrlSplitInvalidHostName() throws Exception {
+        BalancedClickhouseDataSource.splitUrl("jdbc:clickhouse://localhost:1234,_0ano^ther-host.com:4321");
+
+    }
+
+
     @BeforeTest
     public void setUp() throws Exception {
         ClickHouseProperties properties = new ClickHouseProperties();


### PR DESCRIPTION
… it works with dashes.

Sorry, I could not run all the tests locally since they seem to expect a ClickHouse server running at localhost.