### PR TITLE
Setting Nullable Metadata based of Column Type.

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -855,7 +855,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
             row.add(String.valueOf(colNum));
             colNum += 1;
             //IS_NULLABLE
-            row.add("NO");
+            row.add(TypeUtils.isTypeNull(type));
 
             //"SCOPE_CATALOG",
             row.add(null);

--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -13,6 +13,9 @@ import java.sql.Types;
  */
 public class TypeUtils {
 
+    public static final String NULLABLE_YES = "YES";
+    public static final String NULLABLE_NO = "NO";
+
     public static int toSqlType(String clickshouseType) {
         if (isNullable(clickshouseType)) {
             clickshouseType = unwrapNullable(clickshouseType);
@@ -111,4 +114,11 @@ public class TypeUtils {
         }
     }
 
+    public static String isTypeNull(String clickshouseType) {
+        if(isNullable(clickshouseType)){
+            return NULLABLE_YES;
+        }else{
+            return NULLABLE_NO;
+        }
+    }
 }

--- a/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
@@ -1,0 +1,19 @@
+package ru.yandex.clickhouse.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static ru.yandex.clickhouse.util.TypeUtils.NULLABLE_NO;
+import static ru.yandex.clickhouse.util.TypeUtils.NULLABLE_YES;
+
+public class TypeUtilsTest {
+
+  @Test
+  public void testTypeIsNullable() throws Exception {
+    assertEquals(NULLABLE_NO,TypeUtils.isTypeNull("DateTime"));
+    assertEquals(NULLABLE_NO,TypeUtils.isTypeNull("Float64"));
+    assertEquals(NULLABLE_YES,TypeUtils.isTypeNull("Nullable(Float64)"));
+    assertEquals(NULLABLE_YES,TypeUtils.isTypeNull("Nullable(DateTime)"));
+  }
+
+}


### PR DESCRIPTION
Currently, we return isNull NO for all the columns in Click house table. This pull request checks the column type to be nullable and return the correct value. 