### PR TITLE
Specialize on connection type in Balanced data source

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
@@ -6,7 +6,6 @@ import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.*;

--- a/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
@@ -186,7 +186,7 @@ public class BalancedClickhouseDataSource implements DataSource {
      * {@inheritDoc}
      */
     @Override
-    public Connection getConnection() throws SQLException {
+    public ClickHouseConnection getConnection() throws SQLException {
         return driver.connect(getAnyUrl(), properties);
     }
 
@@ -194,7 +194,7 @@ public class BalancedClickhouseDataSource implements DataSource {
      * {@inheritDoc}
      */
     @Override
-    public Connection getConnection(String username, String password) throws SQLException {
+    public ClickHouseConnection getConnection(String username, String password) throws SQLException {
         return driver.connect(getAnyUrl(), properties.withCredentials(username, password));
     }
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDataSource.java
@@ -5,7 +5,6 @@ import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;


### PR DESCRIPTION
Ordinary `ClickHouseConnection` does this, so for the sake of consistency & convenience, can we have this without resorting to casts on call sites?