### PR TITLE
Metadata column fixes

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -821,15 +821,8 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
             row.add("0");
             //buffer length
             row.add("0");
-
             // decimal digits
-            if (sqlType == Types.INTEGER || sqlType == Types.BIGINT && type.contains("Int")) {
-                String bits = type.substring(type.indexOf("Int") + "Int".length());
-                row.add(bits);
-            } else {
-                row.add(null);
-            }
-
+            row.add(Integer.toString(TypeUtils.getDecimalDigits(type)));
             // radix
             row.add("10");
             // nullable

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -817,8 +817,8 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
             row.add(Integer.toString(sqlType));
             //type name
             row.add(type);
-            // column size ?
-            row.add("0");
+            // column size / precision
+            row.add(Integer.toString(TypeUtils.getColumnSize(type)));
             //buffer length
             row.add("0");
             // decimal digits

--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -114,6 +114,20 @@ public class TypeUtils {
         }
     }
 
+    public static int getDecimalDigits(String type) {
+        if (isNullable(type)) {
+            type = unwrapNullable(type);
+        }
+
+        if (type.equals("Float32")) {
+            return 8;
+        } else if (type.equals("Float64")) {
+            return 17;
+        }
+        // no other types support decimal digits
+        return 0;
+    }
+
     public static String isTypeNull(String clickshouseType) {
         if(isNullable(clickshouseType)){
             return NULLABLE_YES;

--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -114,6 +114,46 @@ public class TypeUtils {
         }
     }
 
+    public static int getColumnSize(String type) {
+        if (isNullable(type)) {
+            type = unwrapNullable(type);
+        }
+
+        if (type.equals("Float32")) {
+            return 8;
+        } else if (type.equals("Float64")) {
+            return 17;
+        } else if (type.equals("Int8")) {
+            return 4;
+        } else if (type.equals("Int16")) {
+            return 6;
+        } else if (type.equals("Int32")) {
+            return 11;
+        } else if (type.equals("Int64")) {
+            return 20;
+        } else if (type.equals("UInt8")) {
+            return 3;
+        } else if (type.equals("UInt16")) {
+            return 5;
+        } else if (type.equals("UInt32")) {
+            return 10;
+        } else if (type.equals("UInt64")) {
+            return 19;
+        } else if (type.equals("Date")) {
+            // number of chars in '2018-01-01'
+            return 10;
+        } else if (type.equals("DateTime")) {
+            // number of chars in '2018-01-01 01:02:35'
+            return 19;
+        } else if (type.startsWith("FixedString(")) {
+            String numBytes = type.substring("FixedString(".length(), type.length() - 1);
+            return Integer.parseInt(numBytes);
+        } else {
+            // size unknown
+            return 0;
+        }
+    }
+
     public static int getDecimalDigits(String type) {
         if (isNullable(type)) {
             type = unwrapNullable(type);

--- a/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
@@ -3,6 +3,7 @@ package ru.yandex.clickhouse.util;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static ru.yandex.clickhouse.util.TypeUtils.NULLABLE_NO;
 import static ru.yandex.clickhouse.util.TypeUtils.NULLABLE_YES;
 
@@ -14,6 +15,20 @@ public class TypeUtilsTest {
     assertEquals(NULLABLE_NO,TypeUtils.isTypeNull("Float64"));
     assertEquals(NULLABLE_YES,TypeUtils.isTypeNull("Nullable(Float64)"));
     assertEquals(NULLABLE_YES,TypeUtils.isTypeNull("Nullable(DateTime)"));
+  }
+
+  @Test
+  public void testGetDecimalDigits() throws Exception {
+      assertEquals(TypeUtils.getDecimalDigits("DateTime"), 0);
+      assertEquals(TypeUtils.getDecimalDigits("Int32"), 0);
+      assertEquals(TypeUtils.getDecimalDigits("Array(String)"), 0);
+      assertEquals(TypeUtils.getDecimalDigits("Nullable(Int32)"), 0);
+      assertEquals(TypeUtils.getDecimalDigits("Nullable(DateTime)"), 0);
+
+      assertEquals(TypeUtils.getDecimalDigits("Float64"), 17);
+      assertEquals(TypeUtils.getDecimalDigits("Nullable(Float64)"), 17);
+      assertEquals(TypeUtils.getDecimalDigits("Float32"), 8);
+      assertEquals(TypeUtils.getDecimalDigits("Nullable(Float32)"), 8);
   }
 
 }

--- a/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/TypeUtilsTest.java
@@ -31,4 +31,20 @@ public class TypeUtilsTest {
       assertEquals(TypeUtils.getDecimalDigits("Nullable(Float32)"), 8);
   }
 
+  @Test
+  public void testGetColumnSize() throws Exception {
+      assertEquals(TypeUtils.getColumnSize("DateTime"), 19);
+      assertEquals(TypeUtils.getColumnSize("Date"), 10);
+      assertEquals(TypeUtils.getColumnSize("UInt8"), 3);
+      assertEquals(TypeUtils.getColumnSize("Int32"), 11);
+      assertEquals(TypeUtils.getColumnSize("Float32"), 8);
+      assertEquals(TypeUtils.getColumnSize("String"), 0);
+      assertEquals(TypeUtils.getColumnSize("FixedString(12)"), 12);
+      assertEquals(TypeUtils.getColumnSize("Enum8"), 0);
+      assertEquals(TypeUtils.getColumnSize("Array(String)"), 0);
+
+      assertEquals(TypeUtils.getColumnSize("Nullable(Int32)"), 11);
+      assertEquals(TypeUtils.getColumnSize("Nullable(DateTime)"), 19);
+      assertEquals(TypeUtils.getColumnSize("Nullable(FixedString(4))"), 4);
+  }
 }


### PR DESCRIPTION
Fixes:
1. Decimal digits - this now returns the number of fractional digits (as per the jdbc spec), and also works for nullable types.
2. Column size - the precision of the type, or the width in characters if a Date/DateTime