### PR TITLE
Fix #175

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -60,6 +60,8 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     private boolean usesWithTotals;
 
+    private boolean lastReached = false;
+
     public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
         this.db = db;
         this.table = table;
@@ -108,19 +110,21 @@ public class ClickHouseResultSet extends AbstractResultSet {
     }
 
     public boolean hasNext() throws SQLException {
-        if (nextLine == null) {
+        if (nextLine == null && !lastReached) {
             try {
                 nextLine = bis.next();
 
                 if (nextLine == null || (maxRows != 0 && rowNumber >= maxRows) || (usesWithTotals && nextLine.length() == 0)) {
                     if (usesWithTotals) {
-                        if(onTheSeparatorRow()) {
+                        if (onTheSeparatorRow()) {
                             totalLine = bis.next();
                             bis.close();
+                            lastReached = true;
                             nextLine = null;
                         } // otherwise do not close the stream, it is single column or invalid result set case
                     } else {
                         bis.close();
+                        lastReached = true;
                         nextLine = null;
                     }
                 }

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -121,14 +121,10 @@ public class ClickHouseResultSet extends AbstractResultSet {
                     if (usesWithTotals) {
                         if (onTheSeparatorRow()) {
                             totalLine = bis.next();
-                            bis.close();
-                            lastReached = true;
-                            nextLine = null;
+                            endOfStream();
                         } // otherwise do not close the stream, it is single column or invalid result set case
                     } else {
-                        bis.close();
-                        lastReached = true;
-                        nextLine = null;
+                        endOfStream();
                     }
                 }
             } catch (IOException e) {
@@ -137,6 +133,13 @@ public class ClickHouseResultSet extends AbstractResultSet {
         }
         return nextLine != null;
     }
+
+    private void endOfStream() throws IOException {
+        bis.close();
+        lastReached = true;
+        nextLine = null;
+    }
+
     @Override
     public boolean next() throws SQLException {
         if (hasNext()) {

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -60,6 +60,9 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     private boolean usesWithTotals;
 
+    // NOTE this can't be used for `isLast` impl because
+    // it does not do prefetch. It is effectively a witness
+    // to the fact that rs.next() returned false.
     private boolean lastReached = false;
 
     public ClickHouseResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {


### PR DESCRIPTION
Quick and dirty - just making sure we don't ask anything on closed streams.

Added ttest w/o this fix fails on the first `rs.next()` call after we reach end of RS.