### PR TITLE
Maven shade plugin for uber jars with shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,37 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.1.0</version>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <relocations>
+                      <relocation>
+                        <pattern>com</pattern>
+                        <shadedPattern>ru.yandex.repackaged.com</shadedPattern>
+                      </relocation>
+                      <relocation>
+                        <pattern>org</pattern>
+                        <shadedPattern>ru.yandex.repackaged.org</shadedPattern>
+                      </relocation>
+                      <relocation>
+                        <pattern>net</pattern>
+                        <shadedPattern>ru.yandex.repackaged.net</shadedPattern>
+                      </relocation>
+                    </relocations>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,6 @@
                     <goal>shade</goal>
                   </goals>
                   <configuration>
-                    <minimizeJar>true</minimizeJar>
                     <relocations>
                       <relocation>
                         <pattern>com</pattern>


### PR DESCRIPTION
The `clickhouse-jdbc` strictly depends on such libraries like `com.google.guava` & `com.fasterxml.jackson.core` well known of its issues with backward/forward compatibilities.

I faced the classpath issues when tried to use `clickhouse-jdbc` with Apache Spark 2.3 (depends on Guava v14). Adding the dependency on shaded jar will solve the issue.
Such approach is widely used for the artifacts with dependcies on Guava, Jackson, etc. (see [google](https://search.maven.org/#search%7Cga%7C1%7Ccom.google.cloud.bigdataoss) provides shaded jars for its dependencies)
