### PR TITLE
Support insert of array of nullables

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
@@ -102,7 +102,7 @@ public class ClickHouseArrayUtil {
 
 
     public static String toString(Object[] values) {
-        if (values.length > 0 && (values[0].getClass().isArray() || values[0] instanceof Collection)) {
+        if (values.length > 0 && values[0] != null && (values[0].getClass().isArray() || values[0] instanceof Collection)) {
             // quote is false to avoid escaping inner '['
             ArrayBuilder builder = new ArrayBuilder(false);
             for (Object value : values) {
@@ -127,7 +127,14 @@ public class ClickHouseArrayUtil {
     }
 
     private static boolean needQuote(Object[] objects) {
-        return objects.length == 0 || !(objects[0] instanceof Number);
+        Object o = null;
+            for (Object u : objects) {
+                if (u != null) {
+                    o = u;
+                    break;
+                }
+            }
+        return objects.length == 0 || !(o instanceof Number);
     }
 
     private static class ArrayBuilder {
@@ -142,22 +149,26 @@ public class ClickHouseArrayUtil {
         }
 
         private ArrayBuilder append(Object value) {
-            String serializedValue = value.toString();
-            if (quote) {
+            String serializedValue = null;
+            boolean nullValue = true;
+            if (value != null) {
+                serializedValue = value.toString();
+                nullValue = false;
+            }
+            if (quote || nullValue) {
                 serializedValue = ClickHouseUtil.escape(serializedValue);
             }
-
             if (built) {
                 throw new IllegalStateException("Already built");
             }
             if (size > 0) {
                 builder.append(',');
             }
-            if (quote) {
+            if (quote && !nullValue) {
                 builder.append('\'');
             }
             builder.append(serializedValue);
-            if (quote) {
+            if (quote  && !nullValue) {
                 builder.append('\'');
             }
             size++;

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
@@ -137,5 +137,41 @@ public class ClickHouseArrayUtilTest {
             ClickHouseArrayUtil.toString(arrayOfArrays),
             "[['a','b'],['c','d']]"
         );
+
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, null))),
+            "[21,\\N]"
+        );
+
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, 42))),
+            "[\\N,42]"
+        );
+
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", null))),
+            "['a',\\N]"
+        );
+
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, "b"))),
+            "[\\N,'b']"
+        );
+
+        arrayOfArrays = new ArrayList<Object>();
+        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(null, 'b')));
+        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', 'd')));
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(arrayOfArrays),
+            "[[\\N,'b'],['c','d']]"
+        );
+
+        arrayOfArrays = new ArrayList<Object>();
+        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(null, 'b')));
+        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', null)));
+        Assert.assertEquals(
+            ClickHouseArrayUtil.toString(arrayOfArrays),
+            "[[\\N,'b'],['c',\\N]]"
+        );
     }
 }


### PR DESCRIPTION
Clickhouse supports insertion of array of nullables:
eg.
```
:) desc test_array_nullable_strings

DESCRIBE TABLE test_array_nullable_strings

┌─name─────────┬─type────────────────────┬─default_type─┬─default_expression─┐
│ date         │ Date                    │              │                    │
│ string       │ String                  │              │                    │
│ array_string │ Array(Nullable(String)) │              │                    │
│ s2           │ Nullable(String)        │              │                    │
│ a2           │ Array(String)           │              │                    │
│ a3           │ Array(Nullable(UInt16)) │              │                    │
└──────────────┴─────────────────────────┴──────────────┴────────────────────┘

:) insert into test_array_nullable_strings values ('2018-03-01', 'hello', ['c', 'd', null, null, 'f'], null, ['b', 'c', 'a'], [null])

:) select * from test_array_nullable_strings

SELECT *
FROM test_array_nullable_strings 

┌───────date─┬─string─┬─array_string────────────┬─s2─┬─a2────────────┬─a3─────────┐
│ 2018-03-01 │ hello  │ ['c','d',NULL,NULL,'f'] │ \N │ ['b','c','a'] │ [NULL]     │
└────────────┴────────┴─────────────────────────┴────┴───────────────┴────────────┘
```

But the JDBC does not.

This PR supports insertion of nullables and also includes test.
