### PR TITLE
Fix set default connection config for PoolingHttpClientConnectionManager

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
@@ -80,6 +80,7 @@ public class ClickHouseHttpClientBuilder {
 
         connectionManager.setDefaultMaxPerRoute(properties.getDefaultMaxPerRoute());
         connectionManager.setMaxTotal(properties.getMaxTotal());
+        connectionManager.setDefaultConnectionConfig(getConnectionConfig());
         return connectionManager;
     }
 


### PR DESCRIPTION
To check fix please set breakpoint in constructor DefaultBHttpClientConnection on query execution.
You will see default buffer size 8kb.