### PR TITLE
Add support for NaN values for floats and doubles

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ByteFragmentUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ByteFragmentUtils.java
@@ -1,6 +1,7 @@
 package ru.yandex.clickhouse.response;
 
 
+import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Primitives;
 
 import java.math.BigInteger;
@@ -205,10 +206,20 @@ final class ByteFragmentUtils {
                     BigInteger bigIntegerValue = new BigInteger(fragment.asString(true));
                     java.lang.reflect.Array.set(array, index++, bigIntegerValue);
                 } else if (elementClass == Float.class) {
-                    Float floatValue = Float.parseFloat(fragment.asString());
+                    Float floatValue;
+                    if (fragment.length() == 3 && fragment.charAt(0) == 'n' && fragment.charAt(1) == 'a' && fragment.charAt(2) == 'n') {
+                        floatValue = Float.NaN;
+                    } else {
+                        floatValue = Float.parseFloat(fragment.asString());
+                    }
                     java.lang.reflect.Array.set(array, index++, floatValue);
                 } else if (elementClass == Double.class) {
-                    Double doubleValue = Double.parseDouble(fragment.asString());
+                    Double doubleValue;
+                    if (fragment.length() == 3 && fragment.charAt(0) == 'n' && fragment.charAt(1) == 'a' && fragment.charAt(2) == 'n') {
+                        doubleValue = Double.NaN;
+                    } else {
+                        doubleValue = Double.parseDouble(fragment.asString());
+                    }
                     java.lang.reflect.Array.set(array, index++, doubleValue);
                 } else if (elementClass == Date.class) {
                     Date dateValue;

--- a/src/test/java/ru/yandex/clickhouse/response/ByteFragmentUtilsTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ByteFragmentUtilsTest.java
@@ -79,6 +79,52 @@ public class ByteFragmentUtilsTest {
         };
     }
 
+    @DataProvider(name = "doubleArrayWithNan")
+    public Object[][] doubleArrayWithNan() {
+        return new Object[][]{
+                { new String[]{ "nan", "23.45" }, new double[]{Double.NaN, 23.45}},
+                { new String[]{}, new double[]{}}
+        };
+    }
+
+    @DataProvider(name = "floatArrayWithNan")
+    public Object[][] floatArrayWithNan() {
+        return new Object[][]{
+                { new String[]{ "nan", "23.45" }, new float[]{Float.NaN, 23.45F}},
+                { new String[]{}, new float[]{}}
+        };
+    }
+
+    @Test(dataProvider = "doubleArrayWithNan")
+    public void testDoubleNan(String[] source, double[] expected) throws Exception
+    {
+        String sourceString = source.length == 0 ? "[]" : "['" + Joiner.on("','").join(Iterables.transform(Arrays.asList(source), new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("'", "\\'");
+            }
+        })) + "']";
+        byte[] bytes = sourceString.getBytes(StreamUtils.UTF_8);
+        ByteFragment fragment = new ByteFragment(bytes, 0, bytes.length);
+        double[] arr= (double[]) ByteFragmentUtils.parseArray(fragment, Double.class);
+        assertEquals(arr, expected);
+    }
+
+    @Test(dataProvider = "floatArrayWithNan")
+    public void testFloatNan(String[] source, float[] expected) throws Exception
+    {
+        String sourceString = source.length == 0 ? "[]" : "['" + Joiner.on("','").join(Iterables.transform(Arrays.asList(source), new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("'", "\\'");
+            }
+        })) + "']";
+        byte[] bytes = sourceString.getBytes(StreamUtils.UTF_8);
+        ByteFragment fragment = new ByteFragment(bytes, 0, bytes.length);
+        float[] arr= (float[]) ByteFragmentUtils.parseArray(fragment, Float.class);
+        assertEquals(arr, expected);
+    }
+
     @Test(dataProvider = "stringArray")
     public void testParseArray(String[] array) throws Exception {
         String sourceString = array.length == 0 ? "[]" : "['" + Joiner.on("','").join(Iterables.transform(Arrays.asList(array), new Function<String, String>() {


### PR DESCRIPTION
We faced an issue, when client is unable to deal with nan values from CH.
```
DESCRIBE TABLE uds_selector_results_Dc_60

┌─name───────────────┬─type───────────┬─default_type─┬─default_expression─┐
│ ts                 │ DateTime       │              │                    │
│ calculation_values │ Array(Float32) │              │                    │
└────────────────────┴────────────────┴──────────────┴────────────────────┘
Sample data:
┌──────────────────ts─┬─calculation_values────────────┐
│ 2018-04-09 15:44:00 │ [533,nan,0,270,250]           │
│ 2018-04-09 15:44:00 │ [1329,0.14597441,12,1002,994] │
│ 2018-04-09 15:42:00 │ [529,nan,0,269,248]           │
└─────────────────────┴───────────────────────────────┘

```
Current implementation fails with:
```
java.lang.NumberFormatException: For input string: "nan"
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
	at sun.misc.FloatingDecimal.parseFloat(FloatingDecimal.java:122)
	at java.lang.Float.parseFloat(Float.java:451)
	at ru.yandex.clickhouse.response.ByteFragmentUtils.parseArray(ByteFragmentUtils.java:208)
	at ru.yandex.clickhouse.response.ByteFragmentUtils.parseArray(ByteFragmentUtils.java:154)
	at ru.yandex.clickhouse.response.ClickHouseResultSet.getArray(ClickHouseResultSet.java:249)
	at ru.yandex.clickhouse.response.ClickHouseResultSet.getArray(ClickHouseResultSet.java:261
```
The following PR should fix that behaviour.