### PR TITLE
Returning true value of IsNullable from ClickHouseResultSetMetaData

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,14 @@
             <artifactId>joda-time</artifactId>
             <version>2.9.9</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSetMetaData.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSetMetaData.java
@@ -40,12 +40,12 @@ public class ClickHouseResultSetMetaData implements ResultSetMetaData {
 
     @Override
     public int isNullable(int column) throws SQLException {
-        return columnNoNulls;
+        return columnTypeAt(column).startsWith("Nullable(") ? columnNullable : columnNoNulls;
     }
 
     @Override
     public boolean isSigned(int column) throws SQLException {
-        return !resultSet.getTypes()[column - 1].startsWith("U");
+        return !columnTypeAt(column).startsWith("U");
     }
 
     @Override
@@ -98,7 +98,7 @@ public class ClickHouseResultSetMetaData implements ResultSetMetaData {
         if (resultSet.getTypes().length < column) {
             throw new ArrayIndexOutOfBoundsException("Array length: " + resultSet.getTypes().length + " requested: " + (column - 1));
         }
-        return resultSet.getTypes()[column - 1];
+        return columnTypeAt(column);
     }
 
     @Override
@@ -139,5 +139,9 @@ public class ClickHouseResultSetMetaData implements ResultSetMetaData {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         return iface != null && iface.isAssignableFrom(getClass());
+    }
+
+    private String columnTypeAt(int column) {
+        return resultSet.getTypes()[column - 1];
     }
 }

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetMetaDataTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetMetaDataTest.java
@@ -1,0 +1,29 @@
+package ru.yandex.clickhouse.response;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ClickHouseResultSetMetaDataTest {
+
+
+  @Test
+  public void testIsNullable() throws SQLException {
+
+    ClickHouseResultSet resultSet = mock(ClickHouseResultSet.class);
+    String[] types = new String[] { "DateTime" , "Nullable(Float64)"};
+    when(resultSet.getTypes()).thenReturn(types);
+
+
+    ClickHouseResultSetMetaData resultSetMetaData = new ClickHouseResultSetMetaData(resultSet);
+
+    Assert.assertEquals(resultSetMetaData.isNullable(1), ResultSetMetaData.columnNoNulls);
+    Assert.assertEquals(resultSetMetaData.isNullable(2), ResultSetMetaData.columnNullable);
+  }
+
+}


### PR DESCRIPTION
ResultSetMetaData::isNullable method should return nullability of values in the designated column.
Currently, Clickhouse returns columnNoNulls for all columns including Nullable. This patch fixes the issue. 