### PR TITLE
Add ResultSet isClosed implementation

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -175,6 +175,15 @@ public class ClickHouseResultSet extends AbstractResultSet {
         }
     }
 
+    @Override
+    public boolean isClosed() throws SQLException {
+        try {
+            return bis.isClosed();
+        } catch (IOException e) {
+            throw new SQLException(e);
+        }
+    }
+
     public void getTotals() throws SQLException {
         if (!usesWithTotals)
             throw new IllegalStateException("Cannot get totals when totals are not being used.");

--- a/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
+++ b/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
@@ -27,6 +27,8 @@ public class StreamSplitter {
 
     private boolean readOnce;
 
+    private boolean closed;
+
 
     public StreamSplitter(ByteFragment bf, byte sep) {
         this.delegate = bf.asStream();
@@ -121,7 +123,12 @@ public class StreamSplitter {
      }
 
     public void close() throws IOException {
+        closed = true;
         delegate.close();
+    }
+
+    public boolean isClosed() throws IOException {
+        return closed;
     }
 
     @Override


### PR DESCRIPTION
Using clickhouse-jdbc in PAX-JDBC (Apache Karaf) fails, because ResultSet::isClosed throws UnsupportedOperationException.
I've try to implement this method.