### PR TITLE
Fix checksum calculation

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseCityHash.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseCityHash.java
@@ -59,15 +59,15 @@ public class ClickHouseCityHash {
                 ((b[i+1] & 255) <<  8) +
                 ((b[i+0] & 255) <<  0));
     }
-    private  static int toIntLE(byte[] b, int i) {
-        return (((b[i+3] & 255) << 24) + ((b[i+2] & 255) << 16) + ((b[i+1] & 255) << 8) + ((b[i+0] & 255) << 0));
+    private static long toIntLE(byte[] b, int i) {
+        return (((b[i+3] & 255L) << 24) + ((b[i+2] & 255L) << 16) + ((b[i+1] & 255L) << 8) + ((b[i+0] & 255L) << 0));
     }
 
     private static long fetch64(byte[] s, int pos) {
         return toLongLE(s, pos);
     }
 
-    private static int fetch32(byte[] s, int pos) {
+    private static long fetch32(byte[] s, int pos) {
         return toIntLE(s, pos);
     }
 

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
@@ -1,0 +1,34 @@
+package ru.yandex.clickhouse.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import ru.yandex.clickhouse.response.ClickHouseLZ4Stream;
+
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * @author Anton Sukhonosenko <a href="mailto:algebraic@yandex-team.ru"></a>
+ * @date 08.06.18
+ */
+public class ClickHouseBlockChecksumTest {
+    private static final int HEADER_SIZE_BYTES = 9;
+
+    @Test
+    public void calculateChecksum() {
+        byte[] compressedData = DatatypeConverter.parseHexBinary("1F000100078078000000B4000000");
+        int uncompressedSizeBytes = 35;
+
+        ClickHouseBlockChecksum checksum = ClickHouseBlockChecksum.calculateForBlock(
+            (byte) ClickHouseLZ4Stream.MAGIC,
+            compressedData.length + HEADER_SIZE_BYTES,
+            uncompressedSizeBytes,
+            compressedData,
+            compressedData.length
+        );
+
+        Assert.assertEquals(
+            DatatypeConverter.printHexBinary(checksum.asBytes()),
+            "923AF569343D26F98EAEF00EEFEC36A9"
+        );
+    }
+}


### PR DESCRIPTION
We've faced with the problem, that Clickhouse sometimes rejected our queries with "Invalid checksum" error. I sniffed the query and sent it to Clickhouse team. They said that it indeed has invalid checksum in last block.

I took the last block, thanks god it's very small. Then I has wirtten 2 tests — in C++ using cityhash library from clickhouse codebase and ``ClickHouseBlockChecksumTest.java`` (expected hash code is taken from C++ test).

Then I debugged them both step-by-step and finally tracked the mistake. 

The problem is in ``fetch32`` method, that returns ``int``, but then this value explicitly is casted to ``long``: https://github.com/yandex/clickhouse-jdbc/blob/master/src/main/java/ru/yandex/clickhouse/util/ClickHouseCityHash.java#L107

This casting leads to incorrect result if we have ``1`` in the first bit (responsible for sign), because it moves to first position in 64-bit ``long``. Thus we have:
``0x80000000`` --(cast to long)-> ``0xFFFFFFFF80000000``

I changed type to ``long`` in the first place in order to eliminate this.
 

