### PR TITLE
Add support for arbitrary query params

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
@@ -17,9 +17,18 @@ public interface ClickHouseStatement extends Statement {
 
     ClickHouseResponse executeQueryClickhouseResponse(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
 
+    ClickHouseResponse executeQueryClickhouseResponse(String sql,
+                                                      Map<ClickHouseQueryParam, String> additionalDBParams,
+                                                      Map<String, String> additionalRequestParams) throws SQLException;
+
     ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
 
     ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, List<ClickHouseExternalData> externalData) throws SQLException;
+
+    ResultSet executeQuery(String sql,
+                           Map<ClickHouseQueryParam, String> additionalDBParams,
+                           List<ClickHouseExternalData> externalData,
+                           Map<String, String> additionalRequestParams) throws SQLException;
 
     void sendStream(InputStream content, String table) throws SQLException;
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -1,18 +1,5 @@
 package ru.yandex.clickhouse;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLWarning;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import com.google.common.base.Strings;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -36,8 +23,26 @@ import ru.yandex.clickhouse.response.ClickHouseResultSet;
 import ru.yandex.clickhouse.response.FastByteArrayOutputStream;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
-import ru.yandex.clickhouse.util.*;
+import ru.yandex.clickhouse.util.ClickHouseFormat;
+import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
+import ru.yandex.clickhouse.util.ClickHouseStreamHttpEntity;
+import ru.yandex.clickhouse.util.Patterns;
+import ru.yandex.clickhouse.util.Utils;
 import ru.yandex.clickhouse.util.guava.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 public class ClickHouseStatementImpl implements ClickHouseStatement {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -1,5 +1,18 @@
 package ru.yandex.clickhouse;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import com.google.common.base.Strings;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -23,26 +36,8 @@ import ru.yandex.clickhouse.response.ClickHouseResultSet;
 import ru.yandex.clickhouse.response.FastByteArrayOutputStream;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
-import ru.yandex.clickhouse.util.ClickHouseFormat;
-import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
-import ru.yandex.clickhouse.util.ClickHouseStreamHttpEntity;
-import ru.yandex.clickhouse.util.Patterns;
-import ru.yandex.clickhouse.util.Utils;
+import ru.yandex.clickhouse.util.*;
 import ru.yandex.clickhouse.util.guava.StreamUtils;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLWarning;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 
 public class ClickHouseStatementImpl implements ClickHouseStatement {
@@ -91,7 +86,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
 
     @Override
     public ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, List<ClickHouseExternalData> externalData) throws SQLException {
-        return null;
+        return executeQuery(sql, additionalDBParams, externalData, null);
     }
 
     @Override

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -1,6 +1,7 @@
 package ru.yandex.clickhouse;
 
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.testng.annotations.Test;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
@@ -48,7 +49,7 @@ public class ClickHouseStatementTest {
                 HttpClientBuilder.create().build(),null, withCredentials
                 );
 
-        URI uri = statement.buildRequestUri(null, null, null, false);
+        URI uri = statement.buildRequestUri(null, null, null, null, false);
         String query = uri.getQuery();
         assertTrue(query.contains("password=test_password"));
         assertTrue(query.contains("user=test_user"));
@@ -61,8 +62,28 @@ public class ClickHouseStatementTest {
         ClickHouseStatementImpl statement = new ClickHouseStatementImpl(HttpClientBuilder.create().build(), null,
                 properties);
 
-        URI uri = statement.buildRequestUri(null, null, null, false);
+        URI uri = statement.buildRequestUri(null, null, null, null, false);
         String query = uri.getQuery();
         assertTrue(query.contains("max_memory_usage=41"), "max_memory_usage param is missing in URL");
+    }
+
+    @Test
+    public void testAdditionalRequestParams() throws Exception {
+        ClickHouseProperties properties = new ClickHouseProperties();
+        ClickHouseStatementImpl statement = new ClickHouseStatementImpl(
+                HttpClientBuilder.create().build(),
+                null,
+                properties
+        );
+
+        URI uri = statement.buildRequestUri(
+                null,
+                null,
+                null,
+                ImmutableMap.of("cache_namespace", "aaaa"),
+                false
+        );
+        String query = uri.getQuery();
+        assertTrue(query.contains("cache_namespace=aaaa"), "cache_namespace param is missing in URL");
     }
 }


### PR DESCRIPTION
To be able to use with e.g. chproxy (passing parameters such as `cache_namespace` etc)