### PR TITLE
#222 does't support large request (>16Kb)

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/BodyEntityWrapper.java
+++ b/src/main/java/ru/yandex/clickhouse/BodyEntityWrapper.java
@@ -1,0 +1,52 @@
+package ru.yandex.clickhouse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.StringEntity;
+
+import ru.yandex.clickhouse.util.guava.StreamUtils;
+
+/**
+ * Allow to inject sql query in the body, followed by row data
+ */
+public class BodyEntityWrapper extends AbstractHttpEntity {
+    private final StringEntity sql;
+    private final HttpEntity delegate;
+
+	public BodyEntityWrapper(String sql, HttpEntity content) {
+		this.sql = new StringEntity(sql+"\n", StreamUtils.UTF_8);
+		this.delegate = content;
+	}
+
+	@Override
+	public boolean isRepeatable() {
+        return delegate.isRepeatable();
+	}
+
+	@Override
+	public long getContentLength() {
+        return -1;
+	}
+
+	@Override
+	public InputStream getContent() throws IOException, UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void writeTo(OutputStream outstream) throws IOException {
+		sql.writeTo(outstream);
+        delegate.writeTo(outstream);
+        outstream.flush();
+	}
+
+	@Override
+	public boolean isStreaming() {
+        return delegate.isStreaming();
+	}
+
+}

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -686,14 +686,14 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
         // echo -ne '10\n11\n12\n' | POST 'http://localhost:8123/?query=INSERT INTO t FORMAT TabSeparated'
         HttpEntity entity = null;
         try {
-            URI uri = buildRequestUri(sql + " FORMAT " + format.name(), null, null, null, false);
+            URI uri = buildRequestUri(null , null, null, null, false);
+            HttpEntity requestEntity = new BodyEntityWrapper(sql + " FORMAT " + format.name(), content);
 
             HttpPost httpPost = new HttpPost(uri);
             if (properties.isDecompress()) {
-                httpPost.setEntity(new LZ4EntityWrapper(content, properties.getMaxCompressBufferSize()));
-            } else {
-                httpPost.setEntity(content);
+                requestEntity = new LZ4EntityWrapper(requestEntity, properties.getMaxCompressBufferSize());
             }
+            httpPost.setEntity(requestEntity);
             HttpResponse response = client.execute(httpPost);
             entity = response.getEntity();
             checkForErrorAndThrow(entity, response);

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
@@ -13,7 +13,7 @@ import javax.xml.bind.DatatypeConverter;
 public class ClickHouseBlockChecksumTest {
     private static final int HEADER_SIZE_BYTES = 9;
 
-    @Test
+    //@Test
     public void calculateChecksum() {
         byte[] compressedData = DatatypeConverter.parseHexBinary("1F000100078078000000B4000000");
         int uncompressedSizeBytes = 35;

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
@@ -13,7 +13,7 @@ import javax.xml.bind.DatatypeConverter;
 public class ClickHouseBlockChecksumTest {
     private static final int HEADER_SIZE_BYTES = 9;
 
-    //@Test
+    @Test
     public void calculateChecksum() {
         byte[] compressedData = DatatypeConverter.parseHexBinary("1F000100078078000000B4000000");
         int uncompressedSizeBytes = 35;


### PR DESCRIPTION
Hi,

To avoid issue #222, I propose to always send the query parameter in the HTTP body for all insert request.
