### PR TITLE
Fix checksum calculation again

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseCityHash.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseCityHash.java
@@ -71,6 +71,10 @@ public class ClickHouseCityHash {
         return toIntLE(s, pos);
     }
 
+    private static int staticCastToInt(byte b) {
+        return b & 0xFF;
+    }
+
     private static long rotate(long val, int shift) {
         return shift == 0 ? val : (val >>> shift) | (val << (64 - shift));
     }
@@ -111,8 +115,8 @@ public class ClickHouseCityHash {
             byte a = s[pos + 0];
             byte b = s[pos + (len >>> 1)];
             byte c = s[pos + len - 1];
-            int y = (int)a + (((int)b) << 8);
-            int z = len + (((int)c) << 2);
+            int y = staticCastToInt(a) + (staticCastToInt(b) << 8);
+            int z = len + (staticCastToInt(c) << 2);
             return shiftMix(y * k2 ^ z * k3) * k2;
         }
         return k2;

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseBlockChecksumTest.java
@@ -14,7 +14,7 @@ public class ClickHouseBlockChecksumTest {
     private static final int HEADER_SIZE_BYTES = 9;
 
     @Test
-    public void calculateChecksum() {
+    public void trickyBlock() {
         byte[] compressedData = DatatypeConverter.parseHexBinary("1F000100078078000000B4000000");
         int uncompressedSizeBytes = 35;
 
@@ -27,8 +27,27 @@ public class ClickHouseBlockChecksumTest {
         );
 
         Assert.assertEquals(
-            DatatypeConverter.printHexBinary(checksum.asBytes()),
-            "923AF569343D26F98EAEF00EEFEC36A9"
+            new ClickHouseBlockChecksum(-493639813825217902L, -6253550521065361778L),
+            checksum
+        );
+    }
+
+    @Test
+    public void anotherTrickyBlock() {
+        byte[] compressedData = DatatypeConverter.parseHexBinary("80D9CEF753E3A59B3F");
+        int uncompressedSizeBytes = 8;
+
+        ClickHouseBlockChecksum checksum = ClickHouseBlockChecksum.calculateForBlock(
+            (byte) ClickHouseLZ4Stream.MAGIC,
+            compressedData.length + HEADER_SIZE_BYTES,
+            uncompressedSizeBytes,
+            compressedData,
+            compressedData.length
+        );
+
+        Assert.assertEquals(
+            new ClickHouseBlockChecksum(-7135037831041210418L, -8214889029657590490L),
+            checksum
         );
     }
 }


### PR DESCRIPTION
We've faced with incorrectly calculated checksum again (the last time was https://github.com/yandex/clickhouse-jdbc/pull/215).

The problem occurs when negative byte value is casted to int, i.e.
``0x9B`` --(cast to int)--> ``-101``

If we look at the ClickHouse sources
https://github.com/yandex/ClickHouse/blob/6df5d556e5af7aa95154374a1d601ac9c52a7dd7/contrib/libcityhash/src/city.cc#L139
we'll see that all operations are unsigned. It means that we'll obtain ``0x9B`` --(cast to uint32)--> ``155`` in the original code.

I've fixed it and now we have correct unsigned byte-to-int casting too :)

(Ticket in yandex tracker: https://st.yandex-team.ru/MARKETINFRA-3653)