### PR TITLE
Optimize isSelect, isDatabase and executeBatch by removing toUpperCase calls

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl implements ClickHousePreparedStatement {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseStatementImpl.class);
-    private static final Pattern VALUES = Pattern.compile("VALUES[\\s]*\\(");
+    private static final Pattern VALUES = Pattern.compile("(?i)VALUES[\\s]*\\(");
 
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
     private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -370,7 +370,7 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     @Override
     public int[] executeBatch() throws SQLException {
-        Matcher matcher = VALUES.matcher(sql.toUpperCase());
+        Matcher matcher = VALUES.matcher(sql);
         if (!matcher.find()) {
             throw new SQLSyntaxErrorException(
                     "Query must be like 'INSERT INTO [db.]table [(c1, c2, c3)] VALUES (?, ?, ?)'. " +

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -33,6 +33,9 @@ public class ClickHouseStatementTest {
 
         String sql5 = "SHOW ololo FROM ololoed;";
         assertEquals("SHOW ololo FROM ololoed FORMAT TabSeparatedWithNamesAndTypes;", ClickHouseStatementImpl.clickhousifySql(sql5));
+
+        String sql6 = " show ololo FROM ololoed;";
+        assertEquals("show ololo FROM ololoed FORMAT TabSeparatedWithNamesAndTypes;", ClickHouseStatementImpl.clickhousifySql(sql6));
     }
 
     @Test


### PR DESCRIPTION
Replace a call to `toUpperCase` on the whole SQL query with a case-insensitive
match of the beginning of the string.
Converting the query to uppercase is wasteful, especially for "INSERT INTO" queries that can be particularly long.