### PR TITLE
no joda dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.9.9</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,13 +94,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
@@ -20,17 +20,17 @@ public class ClickHouseRowBinaryStream {
     private static final int U_INT8_MAX = (1 << 8) - 1;
     private static final int U_INT16_MAX = (1 << 16) - 1;
     private static final long U_INT32_MAX = (1L << 32) - 1;
-	private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
+    private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
 
     private final LittleEndianDataOutputStream out;
-	private final TimeZone timeZone;
+    private final TimeZone timeZone;
 
     public ClickHouseRowBinaryStream(OutputStream outputStream, TimeZone timeZone, ClickHouseProperties properties) {
         this.out = new LittleEndianDataOutputStream(outputStream);
         if (properties.isUseServerTimeZoneForDates()) {
-	        this.timeZone = timeZone;
+            this.timeZone = timeZone;
         } else {
-	        this.timeZone = TimeZone.getDefault();
+            this.timeZone = TimeZone.getDefault();
         }
     }
 
@@ -146,8 +146,8 @@ public class ClickHouseRowBinaryStream {
 
     public void writeDate(Date date) throws IOException {
         Preconditions.checkNotNull(date);
-	    long localMillis = date.getTime() + timeZone.getOffset(date.getTime());
-	    int daysSinceEpoch = (int) (localMillis / MILLIS_IN_DAY);
+        long localMillis = date.getTime() + timeZone.getOffset(date.getTime());
+        int daysSinceEpoch = (int) (localMillis / MILLIS_IN_DAY);
         writeUInt16(daysSinceEpoch);
     }
 

--- a/src/test/java/ru/yandex/clickhouse/integration/RowBinaryStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/RowBinaryStreamTest.java
@@ -2,8 +2,6 @@ package ru.yandex.clickhouse.integration;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.common.primitives.UnsignedLongs;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -17,6 +15,7 @@ import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.*;
+import java.util.Calendar;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -207,9 +206,7 @@ public class RowBinaryStreamTest {
         Assert.assertEquals(dateArray.length, dates1.length);
         for (int i = 0; i < dateArray.length; i++) {
             // expected is Date at start of the day in local timezone
-            DateTime dt = new DateTime(dates1[i].getTime())
-                    .withTimeAtStartOfDay();
-            Date expected = new Date(dt.toDate().getTime());
+            Date expected = withTimeAtStartOfDay(dates1[i]);
             Assert.assertEquals(dateArray[i], expected);
         }
         final Timestamp[] dateTimeArray = (Timestamp[]) rs.getArray("dateTimeArray").getArray();
@@ -319,10 +316,17 @@ public class RowBinaryStreamTest {
 
         Assert.assertTrue(rs.next());
         Assert.assertEquals(rs.getTime("dateTime"), new Time(date1.getTime()));
-        DateTime dt = new DateTime(date1.getTime())
-                .withTimeAtStartOfDay();
-        Date expectedDate = new Date(dt.toDate().getTime()); // expected start of the day in local timezone
+        Date expectedDate = withTimeAtStartOfDay(date1); // expected start of the day in local timezone
         Assert.assertEquals(rs.getDate("date"), expectedDate);
     }
 
+    private static Date withTimeAtStartOfDay(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return new Date(cal.getTimeInMillis());
+    }
 }

--- a/src/test/java/ru/yandex/clickhouse/integration/TimeZoneTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/TimeZoneTest.java
@@ -1,6 +1,5 @@
 package ru.yandex.clickhouse.integration;
 
-import org.joda.time.LocalDate;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -12,6 +11,7 @@ import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
 
 import java.io.IOException;
 import java.sql.*;
+import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -97,7 +97,7 @@ public class TimeZoneTest {
 
 
         final Date date = new Date(currentTime);
-        Date localStartOfDay = new Date(new LocalDate(currentTime).toDateTimeAtStartOfDay().getMillis());
+        Date localStartOfDay = withTimeAtStartOfDay(date);
 
         connectionServerTz.createStatement().sendRowBinaryStream(
                 "INSERT INTO test.date_insert (i, d)",
@@ -134,5 +134,15 @@ public class TimeZoneTest {
         // inserted in manual timezone
         Assert.assertEquals(rsMan.getDate(1), localStartOfDay);
         Assert.assertEquals(rsSrv.getDate(1), localStartOfDay);
+    }
+
+    private static Date withTimeAtStartOfDay(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return new Date(cal.getTimeInMillis());
     }
 }

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
@@ -1,12 +1,12 @@
 package ru.yandex.clickhouse.util;
 
 import com.google.common.primitives.UnsignedLong;
-import org.joda.time.LocalDate;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Date;
 import java.util.TimeZone;
 
 /**
@@ -85,7 +85,7 @@ public class ClickHouseRowBinaryStreamTest {
                     stream.writeString("a.b.c");
                     stream.writeFloat64(42.21);
                     stream.writeUInt32(1492342562);
-                    stream.writeDate(new LocalDate(2017, 4, 16));
+                    stream.writeDate(new Date(117, 3, 16));
                     stream.writeUInt32(1492350000);
                 }
             },


### PR DESCRIPTION
Joda-time library is used only for calculation of daysSinceEpoch variable if one class. Removing this dependency gives less clutter for java 8 applications that use new date-time classes. 