### PR TITLE
Ability to use sendRowBinaryStream with custom ClickHouseQueryParam

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
@@ -30,9 +30,15 @@ public interface ClickHouseStatement extends Statement {
                            List<ClickHouseExternalData> externalData,
                            Map<String, String> additionalRequestParams) throws SQLException;
 
+    void sendStream(InputStream content, String table, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
+
     void sendStream(InputStream content, String table) throws SQLException;
+
+    void sendRowBinaryStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, ClickHouseStreamCallback callback) throws SQLException;
 
     void sendRowBinaryStream(String sql, ClickHouseStreamCallback callback) throws SQLException;
 
+    void sendNativeStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, ClickHouseStreamCallback callback) throws SQLException;
+    
     void sendNativeStream(String sql, ClickHouseStreamCallback callback) throws SQLException;
 }

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -683,22 +683,37 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
 
     @Override
     public void sendRowBinaryStream(String sql, ClickHouseStreamCallback callback) throws SQLException {
+        sendRowBinaryStream(sql, null, callback);
+    }
+
+    @Override
+    public void sendRowBinaryStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, ClickHouseStreamCallback callback) throws SQLException {
         sendStream(
-            new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone(), properties), sql, ClickHouseFormat.RowBinary, null
+                new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone(), properties), sql, ClickHouseFormat.RowBinary, additionalDBParams
         );
     }
 
     @Override
     public void sendNativeStream(String sql, ClickHouseStreamCallback callback) throws SQLException {
+        sendNativeStream(sql, null, callback);
+    }
+
+    @Override
+    public void sendNativeStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, ClickHouseStreamCallback callback) throws SQLException {
         sendStream(
-            new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone(), properties), sql, ClickHouseFormat.Native, null
+                new ClickHouseStreamHttpEntity(callback, getConnection().getTimeZone(), properties), sql, ClickHouseFormat.Native, additionalDBParams
         );
     }
 
     @Override
     public void sendStream(InputStream content, String table) throws ClickHouseException {
+        sendStream(content, table, null);
+    }
+
+    @Override
+    public void sendStream(InputStream content, String table, Map<ClickHouseQueryParam, String> additionalDBParams) throws ClickHouseException {
         String query = "INSERT INTO " + table;
-        sendStream(new InputStreamEntity(content, -1), query, null, null);
+        sendStream(new InputStreamEntity(content, -1), query, null, additionalDBParams);
     }
 
     public void sendStream(HttpEntity content, String sql) throws ClickHouseException {


### PR DESCRIPTION
This simple PR fixes issue #264 by exposing a sendRowBinaryStream variant allowing custom ClickHouseQueryParam. I also did the same with sendNativeStream and sendStream for symmetry.
