### PR TITLE
serialize null array elements as 'NULL' instead of '\N'

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
@@ -149,27 +149,23 @@ public class ClickHouseArrayUtil {
         }
 
         private ArrayBuilder append(Object value) {
-            String serializedValue = null;
-            boolean nullValue = true;
-            if (value != null) {
-                serializedValue = value.toString();
-                nullValue = false;
-            }
-            if (quote || nullValue) {
-                serializedValue = ClickHouseUtil.escape(serializedValue);
-            }
             if (built) {
                 throw new IllegalStateException("Already built");
             }
             if (size > 0) {
                 builder.append(',');
             }
-            if (quote && !nullValue) {
-                builder.append('\'');
-            }
-            builder.append(serializedValue);
-            if (quote  && !nullValue) {
-                builder.append('\'');
+            if (value != null) {
+                String serializedValue = value.toString();
+                if (quote) {
+                    builder.append('\'');
+                    builder.append(ClickHouseUtil.escape(serializedValue));
+                    builder.append('\'');
+                } else {
+                    builder.append(serializedValue);
+                }
+            } else {
+                builder.append("NULL");
             }
             size++;
             return this;

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -69,6 +69,48 @@ public class ClickHousePreparedStatementTest {
     }
 
     @Test
+    public void testArrayOfNullableIntsTest() throws Exception {
+        connection.createStatement().execute("DROP TABLE IF EXISTS test.array_of_null_ints_test");
+        connection.createStatement().execute(
+                "CREATE TABLE IF NOT EXISTS test.array_of_null_ints_test (i Int32, a Array(Nullable(Int32))) ENGINE = TinyLog"
+        );
+
+        PreparedStatement statement = connection.prepareStatement("INSERT INTO test.array_of_null_ints_test (i, a) VALUES (?, ?)");
+
+        statement.setInt(1, 1);
+        statement.setArray(2, new ClickHouseArray(Types.INTEGER, new Integer[]{1, 2, null, 4}));
+        statement.addBatch();
+        statement.executeBatch();
+
+        ResultSet rs = connection.createStatement().executeQuery("SELECT count() as cnt from test.array_of_null_ints_test");
+        rs.next();
+
+        Assert.assertEquals(rs.getInt("cnt"), 1);
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testArrayOfNullableStringsTest() throws Exception {
+        connection.createStatement().execute("DROP TABLE IF EXISTS test.array_of_null_strings_test");
+        connection.createStatement().execute(
+                "CREATE TABLE IF NOT EXISTS test.array_of_null_strings_test (i Int32, a Array(Nullable(String))) ENGINE = TinyLog"
+        );
+
+        PreparedStatement statement = connection.prepareStatement("INSERT INTO test.array_of_null_strings_test (i, a) VALUES (?, ?)");
+
+        statement.setInt(1, 1);
+        statement.setObject(2, new String[]{"a", "b", null, "d"});
+        statement.addBatch();
+        statement.executeBatch();
+
+        ResultSet rs = connection.createStatement().executeQuery("SELECT count() as cnt from test.array_of_null_strings_test");
+        rs.next();
+
+        Assert.assertEquals(rs.getInt("cnt"), 1);
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
     public void testInsertUInt() throws SQLException {
         connection.createStatement().execute("DROP TABLE IF EXISTS test.unsigned_insert");
         connection.createStatement().execute(

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
@@ -140,22 +140,22 @@ public class ClickHouseArrayUtilTest {
 
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, null))),
-            "[21,\\N]"
+            "[21,NULL]"
         );
 
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, 42))),
-            "[\\N,42]"
+            "[NULL,42]"
         );
 
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", null))),
-            "['a',\\N]"
+            "['a',NULL]"
         );
 
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, "b"))),
-            "[\\N,'b']"
+            "[NULL,'b']"
         );
 
         arrayOfArrays = new ArrayList<Object>();
@@ -163,7 +163,7 @@ public class ClickHouseArrayUtilTest {
         arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', 'd')));
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(arrayOfArrays),
-            "[[\\N,'b'],['c','d']]"
+            "[[NULL,'b'],['c','d']]"
         );
 
         arrayOfArrays = new ArrayList<Object>();
@@ -171,7 +171,7 @@ public class ClickHouseArrayUtilTest {
         arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', null)));
         Assert.assertEquals(
             ClickHouseArrayUtil.toString(arrayOfArrays),
-            "[[\\N,'b'],['c',\\N]]"
+            "[[NULL,'b'],['c',NULL]]"
         );
     }
 }


### PR DESCRIPTION
ClickHouse expects null array elements to be written as 'NULL', not '\N'.
Steps to reproduce:

```
CREATE TABLE test_table ( array Array(Nullable(String)) ) ENGINE = Memory;

> echo "['a', 'b', \N, 'd']" | clickhouse-client --query="INSERT INTO test_table FORMAT TSV"
Code: 26. DB::Exception: Cannot parse quoted string: expected opening quote: (at row 1)

Row 1:
Column 0,   name: array, type: Array(Nullable(String)), parsed text: "[<SINGLE QUOTE>a<SINGLE QUOTE>, <SINGLE QUOTE>b<SINGLE QUOTE>, "ERROR

> echo "['a', 'b', NULL, 'd']" | clickhouse-client --query="INSERT INTO test_table FORMAT TSV"

SELECT *
FROM test_table

┌─array──────────────┐
│ ['a','b',NULL,'d'] │
└────────────────────┘
```