### PR TITLE
Allow dashes and asterisks in jdbc url database part

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
@@ -16,7 +16,7 @@ public class ClickhouseJdbcUrlParser {
     private static final Logger logger = LoggerFactory.getLogger(ClickhouseJdbcUrlParser.class);
     public static final String JDBC_PREFIX = "jdbc:";
     public static final String JDBC_CLICKHOUSE_PREFIX = JDBC_PREFIX + "clickhouse:";
-    public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
+    public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_\\*\\-]+)");
     protected final static String DEFAULT_DATABASE = "default";
 
     private ClickhouseJdbcUrlParser(){


### PR DESCRIPTION
In internal Clickhouse over YT server implementation database may include dashes and asterisks, so we have to allow them.