### PR TITLE
Support for Scrollable ResultSet

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -149,8 +149,8 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
     @Override
     public ClickHouseStatement createStatement(int resultSetType, int resultSetConcurrency,
                                                int resultSetHoldability) throws SQLException {
-        if (resultSetType != ResultSet.TYPE_FORWARD_ONLY && resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
-            && resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+        if (resultSetType == ResultSet.TYPE_SCROLL_SENSITIVE || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
+            || resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
             throw new SQLFeatureNotSupportedException();
         }
         return createStatement();

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
@@ -275,4 +275,150 @@ public class ClickHouseResultSetTest {
         assertTrue(rs.isLast());
         assertFalse(rs.next());
     }
+    
+    @Test
+    public void testPrevious() throws Exception {
+        String response =
+                "SiteName\tcount()\n" +
+                  "String\tUInt64\n" +
+                  "hello.com\t21209048\n" +
+                  "there.com\t49302091\n";
+
+              ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+              ResultSet rs = new ClickHouseResultSet(is, 1024, "db", "table", false, null, null, props);
+
+              rs.next();
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+
+              rs.next();
+              assertEquals("there.com", rs.getString(1));
+              assertEquals(49302091L, rs.getLong(2));
+              
+              rs.previous();
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+    }
+    
+    @Test
+    public void testAbsolute() throws Exception {
+        String response =
+                "SiteName\tcount()\n" +
+                  "String\tUInt64\n" +
+                  "hello.com\t21209048\n" +
+                  "there.com\t49302091\n";
+
+              ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+              ResultSet rs = new ClickHouseResultSet(is, 1024, "db", "table", false, null, null, props);
+
+              rs.absolute(2);
+              assertEquals("there.com", rs.getString(1));
+              assertEquals(49302091L, rs.getLong(2));
+              
+              rs.absolute(1);
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              rs.absolute(-1);
+              assertEquals("there.com", rs.getString(1));
+              assertEquals(49302091L, rs.getLong(2));
+              
+              assertTrue(rs.isLast());
+              
+    }
+    
+    public void testAbsoluteWithTotal() throws Exception {
+        String response = "SiteName\tcount()\n" +
+                "String\tUInt64\n" +
+                "hello.com\t21209048\n" +
+                "there.com\t49302091\n" +
+                "\n" +
+                "\t70511139\n";
+
+      ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+      ClickHouseResultSet rs = new ClickHouseResultSet(is, 1024, "db", "table", false, null, null, props);
+
+      rs.absolute(2);
+      assertEquals("there.com", rs.getString(1));
+      assertEquals(49302091L, rs.getLong(2));
+      
+      rs.absolute(1);
+      assertEquals("hello.com", rs.getString(1));
+      assertEquals(21209048L, rs.getLong(2));
+      
+      rs.absolute(-1);
+      assertEquals("there.com", rs.getString(1));
+      assertEquals(49302091L, rs.getLong(2));
+      
+      assertTrue(rs.isLast());
+      
+      assertFalse(rs.absolute(3));
+      
+      rs.getTotals();
+      assertEquals("", rs.getString(1));
+      assertEquals(70511139L, rs.getLong(2));
+              
+    }
+    
+    @Test
+    public void testRelative() throws Exception {
+        String response =
+                "SiteName\tcount()\n" +
+                  "String\tUInt64\n" +
+                  "hello.com\t21209048\n" +
+                  "there.com\t49302091\n";
+
+              ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+              ResultSet rs = new ClickHouseResultSet(is, 1024, "db", "table", false, null, null, props);
+
+              rs.next();
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              rs.relative(0);
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              rs.relative(1);
+              assertEquals("there.com", rs.getString(1));
+              assertEquals(49302091L, rs.getLong(2));
+
+              rs.relative(-1);
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              assertFalse(rs.relative(5));
+              assertFalse(rs.relative(-5));
+              
+    }
+    
+    @Test
+    public void testBeforeFirst() throws Exception {
+        String response =
+                "SiteName\tcount()\n" +
+                  "String\tUInt64\n" +
+                  "hello.com\t21209048\n" +
+                  "there.com\t49302091\n";
+
+              ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+              ClickHouseResultSet rs = new ClickHouseResultSet(is, 1024, "db", "table", false, null, null, props);
+
+              rs.next();
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              rs.beforeFirst();
+              rs.next();
+              assertEquals("hello.com", rs.getString(1));
+              assertEquals(21209048L, rs.getLong(2));
+              
+              rs.afterLast();
+              assertFalse(rs.hasNext());
+              
+    }
 }


### PR DESCRIPTION
Hi,

For a project, I need a scrollable ResultSet for clickhouse (beeing able to call previous(), first(), last()... methods). I change the ResultSet for making it always scrollable. I do not know if there is a need for still having a "forward only" ResultSet.

Feel free to discuss with me about this change.

Best Regards