### PR TITLE
Support for queries with RowBinary result

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatement.java
@@ -2,6 +2,7 @@ package ru.yandex.clickhouse;
 
 import ru.yandex.clickhouse.response.ClickHouseResponse;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
+import ru.yandex.clickhouse.util.ClickHouseRowBinaryInputStream;
 import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
 
 import java.io.InputStream;
@@ -20,6 +21,15 @@ public interface ClickHouseStatement extends Statement {
     ClickHouseResponse executeQueryClickhouseResponse(String sql,
                                                       Map<ClickHouseQueryParam, String> additionalDBParams,
                                                       Map<String, String> additionalRequestParams) throws SQLException;
+
+    ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql) throws SQLException;
+
+    ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql,
+                                                                         Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
+
+    ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql,
+                                                                         Map<ClickHouseQueryParam, String> additionalDBParams,
+                                                                         Map<String, String> additionalRequestParams) throws SQLException;
 
     ResultSet executeQuery(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -40,6 +40,7 @@ import ru.yandex.clickhouse.response.FastByteArrayOutputStream;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
 import ru.yandex.clickhouse.util.ClickHouseFormat;
+import ru.yandex.clickhouse.util.ClickHouseRowBinaryInputStream;
 import ru.yandex.clickhouse.util.ClickHouseStreamCallback;
 import ru.yandex.clickhouse.util.ClickHouseStreamHttpEntity;
 import ru.yandex.clickhouse.util.Patterns;
@@ -58,6 +59,8 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     private ClickHouseConnection connection;
 
     private ClickHouseResultSet currentResult;
+
+    private ClickHouseRowBinaryInputStream currentRowBinaryResult;
 
     private int currentUpdateCount = -1;
 
@@ -174,6 +177,41 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     }
 
     @Override
+    public ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql) throws SQLException {
+        return executeQueryClickhouseRowBinaryStream(sql, null);
+    }
+
+    @Override
+    public ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException {
+        return executeQueryClickhouseRowBinaryStream(sql, additionalDBParams, null);
+    }
+
+    @Override
+    public ClickHouseRowBinaryInputStream executeQueryClickhouseRowBinaryStream(String sql, Map<ClickHouseQueryParam, String> additionalDBParams, Map<String, String> additionalRequestParams) throws SQLException {
+        InputStream is = getInputStream(
+                addFormatIfAbsent(sql, "RowBinary"),
+                additionalDBParams,
+                null,
+                additionalRequestParams
+        );
+        try {
+            if (isSelect(sql)) {
+                currentUpdateCount = -1;
+                currentRowBinaryResult = new ClickHouseRowBinaryInputStream(properties.isCompress()
+                        ? new ClickHouseLZ4Stream(is) : is, getConnection().getTimeZone(), properties);
+                return currentRowBinaryResult;
+            } else {
+                currentUpdateCount = 0;
+                StreamUtils.close(is);
+                return null;
+            }
+        } catch (Exception e) {
+            StreamUtils.close(is);
+            throw ClickHouseExceptionSpecifier.specify(e, properties.getHost(), properties.getPort());
+        }
+    }
+
+    @Override
     public int executeUpdate(String sql) throws SQLException {
         InputStream is = null;
         try {
@@ -196,6 +234,10 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     public void close() throws SQLException {
         if (currentResult != null) {
             currentResult.close();
+        }
+
+        if (currentRowBinaryResult != null) {
+            StreamUtils.close(currentRowBinaryResult);
         }
     }
 
@@ -415,7 +457,8 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
         if (isSelect(sql)
             && !woSemicolon.endsWith(" TabSeparatedWithNamesAndTypes")
             && !woSemicolon.endsWith(" TabSeparated")
-            && !woSemicolon.endsWith(" JSONCompact")) {
+            && !woSemicolon.endsWith(" JSONCompact")
+            && !woSemicolon.endsWith(" RowBinary")) {
             if (sql.endsWith(";")) {
                 sql = sql.substring(0, sql.length() - 1);
             }

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
@@ -99,7 +99,9 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 	}
 
 	/**
-	 * Warning: the result is negative in Java if UInt8 > 0x7f
+	 * Warning: the result is negative in Java if UInt8 &gt; 0x7f
+	 * @return next UInt8 value as a byte
+	 * @throws IOException
 	 */
 	public byte readUInt8AsByte() throws IOException {
 		return in.readByte();
@@ -114,7 +116,9 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 	}
 
 	/**
-	 * Warning: the result is negative in Java if UInt16 > 0x7fff
+	 * Warning: the result is negative in Java if UInt16 &gt; 0x7fff
+	 * @return next UInt16 value as a short
+	 * @throws IOException
 	 */
 	public short readUInt16AsShort() throws IOException {
 		return in.readShort();
@@ -129,7 +133,9 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 	}
 
 	/**
-	 * Warning: the result is negative in Java if UInt32 > 0x7fffffff
+	 * Warning: the result is negative in Java if UInt32 &gt; 0x7fffffff
+	 * @return next UInt32 value as an int
+	 * @throws IOException
 	 */
 	public int readUInt32AsInt() throws IOException {
 		return in.readInt();
@@ -140,7 +146,9 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 	}
 
 	/**
-	 * Warning: the result is negative in Java if UInt64 > 0x7fffffffffffffff
+	 * Warning: the result is negative in Java if UInt64 &gt; 0x7fffffffffffffff
+	 * @return next UInt64 value as a long
+	 * @throws IOException
 	 */
 	public long readUInt64AsLong() throws IOException {
 		return in.readLong();

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
@@ -1,0 +1,375 @@
+package ru.yandex.clickhouse.util;
+
+import com.google.common.io.LittleEndianDataInputStream;
+import com.google.common.primitives.UnsignedLong;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+import ru.yandex.clickhouse.util.guava.StreamUtils;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static ru.yandex.clickhouse.util.ClickHouseRowBinaryStream.MILLIS_IN_DAY;
+
+public class ClickHouseRowBinaryInputStream implements Closeable {
+	private final LittleEndianDataInputStream in;
+	private final TimeZone timeZone;
+
+	public ClickHouseRowBinaryInputStream(InputStream is, TimeZone timeZone, ClickHouseProperties properties) {
+		this.in = new LittleEndianDataInputStream(is);
+		if (properties.isUseServerTimeZoneForDates()) {
+			this.timeZone = timeZone;
+		} else {
+			this.timeZone = TimeZone.getDefault();
+		}
+	}
+
+	public int readUnsignedLeb128() throws IOException {
+		int value = 0;
+		int read;
+		do {
+			read = in.read();
+			if (read == -1)
+				throw new EOFException();
+
+			value = (value << 7) | (read & 0x7f);
+		} while ((read & 0x80) != 0);
+
+		return value;
+	}
+
+	public void readBytes(byte[] bytes) throws IOException {
+		readBytes(bytes, 0, bytes.length);
+	}
+
+	public void readBytes(byte[] bytes, int offset, int length) throws IOException {
+		while (length > 0) {
+			int read = in.read(bytes, offset, length);
+			if (read == -1)
+				throw new EOFException();
+			offset += read;
+			length -= read;
+		}
+	}
+
+	public int readByte() throws IOException {
+		return in.read();
+	}
+
+	public boolean isNull() throws IOException {
+		int value = readByte();
+		if (value == -1)
+			throw new EOFException();
+
+		validateInt(value, 0, 1, "nullable");
+		return value != 0;
+	}
+
+	public String readString() throws IOException {
+		int length = readUnsignedLeb128();
+		byte[] bytes = new byte[length];
+		readBytes(bytes);
+
+		return new String(bytes, StreamUtils.UTF_8);
+	}
+
+	private void validateInt(int value, int minValue, int maxValue, String dataType) {
+		if (value < minValue || value > maxValue) {
+			throw new IllegalStateException("Not a " + dataType + " value: " + value);
+		}
+	}
+
+	public boolean readBoolean() throws IOException {
+		int value = readUInt8();
+		validateInt(value, 0, 1, "boolean");
+		return value != 0;
+	}
+
+	public short readUInt8() throws IOException {
+		return (short) in.readUnsignedByte();
+	}
+
+	/**
+	 * Warning: the result is negative in Java if UInt8 > 0x7f
+	 */
+	public byte readUInt8AsByte() throws IOException {
+		return in.readByte();
+	}
+
+	public byte readInt8() throws IOException {
+		return in.readByte();
+	}
+
+	public int readUInt16() throws IOException {
+		return in.readUnsignedShort();
+	}
+
+	/**
+	 * Warning: the result is negative in Java if UInt16 > 0x7fff
+	 */
+	public short readUInt16AsShort() throws IOException {
+		return in.readShort();
+	}
+
+	public short readInt16() throws IOException {
+		return in.readShort();
+	}
+
+	public long readUInt32() throws IOException {
+		return ((long) in.readInt()) & 0xffffffffL;
+	}
+
+	/**
+	 * Warning: the result is negative in Java if UInt32 > 0x7fffffff
+	 */
+	public int readUInt32AsInt() throws IOException {
+		return in.readInt();
+	}
+
+	public int readInt32() throws IOException {
+		return in.readInt();
+	}
+
+	/**
+	 * Warning: the result is negative in Java if UInt64 > 0x7fffffffffffffff
+	 */
+	public long readUInt64AsLong() throws IOException {
+		return in.readLong();
+	}
+
+	public UnsignedLong readUInt64AsUnsignedLong() throws IOException {
+		return UnsignedLong.fromLongBits(in.readLong());
+	}
+
+	public BigInteger readUInt64() throws IOException {
+		byte[] bytes = new byte[8];
+		readBytes(bytes);
+		return new BigInteger(bytes);
+	}
+
+	public long readInt64() throws IOException {
+		return in.readLong();
+	}
+
+	public Timestamp readDateTime() throws IOException {
+		long value = readUInt32();
+		return new Timestamp(TimeUnit.SECONDS.toMillis(value));
+	}
+
+	public Date readDate() throws IOException {
+		int daysSinceEpoch = readUInt16();
+		long utcMillis = daysSinceEpoch * MILLIS_IN_DAY;
+		long localMillis = utcMillis - timeZone.getOffset(utcMillis);
+		return new Date(localMillis);
+	}
+
+	public float readFloat32() throws IOException {
+		return in.readFloat();
+	}
+
+	public double readFloat64() throws IOException {
+		return in.readDouble();
+	}
+
+	public Date[] readDateArray() throws IOException {
+		int length = readUnsignedLeb128();
+		Date[] dates = new Date[length];
+		for (int i = 0; i < length; i++) {
+			dates[i] = readDate();
+		}
+
+		return dates;
+	}
+
+	public Timestamp[] readDateTimeArray() throws IOException {
+		int length = readUnsignedLeb128();
+		Timestamp[] dates = new Timestamp[length];
+		for (int i = 0; i < length; i++) {
+			dates[i] = readDateTime();
+		}
+
+		return dates;
+	}
+
+	public String[] readStringArray() throws IOException {
+		int length = readUnsignedLeb128();
+		String[] strings = new String[length];
+		for (int i = 0; i < length; i++) {
+			strings[i] = readString();
+		}
+
+		return strings;
+	}
+
+	public byte[] readInt8Array() throws IOException {
+		int length = readUnsignedLeb128();
+		byte[] bytes = new byte[length];
+		for (int i = 0; i < length; i++) {
+			bytes[i] = readInt8();
+		}
+
+		return bytes;
+	}
+
+	public byte[] readUInt8ArrayAsByte() throws IOException {
+		int length = readUnsignedLeb128();
+		byte[] bytes = new byte[length];
+		for (int i = 0; i < length; i++) {
+			bytes[i] = readUInt8AsByte();
+		}
+
+		return bytes;
+	}
+
+	public short[] readUInt8Array() throws IOException {
+		int length = readUnsignedLeb128();
+		short[] shorts = new short[length];
+		for (int i = 0; i < length; i++) {
+			shorts[i] = readUInt8();
+		}
+
+		return shorts;
+	}
+
+	public short[] readInt16Array() throws IOException {
+		int length = readUnsignedLeb128();
+		short[] shorts = new short[length];
+		for (int i = 0; i < length; i++) {
+			shorts[i] = readInt16();
+		}
+
+		return shorts;
+	}
+
+	public short[] readUInt16ArrayAsShort() throws IOException {
+		int length = readUnsignedLeb128();
+		short[] shorts = new short[length];
+		for (int i = 0; i < length; i++) {
+			shorts[i] = readUInt16AsShort();
+		}
+
+		return shorts;
+	}
+
+	public int[] readUInt16Array() throws IOException {
+		int length = readUnsignedLeb128();
+		int[] ints = new int[length];
+		for (int i = 0; i < length; i++) {
+			ints[i] = readUInt16();
+		}
+
+		return ints;
+	}
+
+	public int[] readInt32Array() throws IOException {
+		int length = readUnsignedLeb128();
+		int[] ints = new int[length];
+		for (int i = 0; i < length; i++) {
+			ints[i] = readInt32();
+		}
+
+		return ints;
+	}
+
+	public int[] readUInt32ArrayAsInt() throws IOException {
+		int length = readUnsignedLeb128();
+		int[] ints = new int[length];
+		for (int i = 0; i < length; i++) {
+			ints[i] = readUInt32AsInt();
+		}
+
+		return ints;
+	}
+
+	public long[] readUInt32Array() throws IOException {
+		int length = readUnsignedLeb128();
+		long[] longs = new long[length];
+		for (int i = 0; i < length; i++) {
+			longs[i] = readUInt32();
+		}
+
+		return longs;
+	}
+
+	public long[] readInt64Array() throws IOException {
+		int length = readUnsignedLeb128();
+		long[] longs = new long[length];
+		for (int i = 0; i < length; i++) {
+			longs[i] = readInt64();
+		}
+
+		return longs;
+	}
+
+	public long[] readUInt64ArrayAsLong() throws IOException {
+		int length = readUnsignedLeb128();
+		long[] longs = new long[length];
+		for (int i = 0; i < length; i++) {
+			longs[i] = readUInt64AsLong();
+		}
+
+		return longs;
+	}
+
+	public UnsignedLong[] readUInt64ArrayAsUnsignedLong() throws IOException {
+		int length = readUnsignedLeb128();
+		UnsignedLong[] longs = new UnsignedLong[length];
+		for (int i = 0; i < length; i++) {
+			longs[i] = readUInt64AsUnsignedLong();
+		}
+
+		return longs;
+	}
+
+	public BigInteger[] readUInt64Array() throws IOException {
+		int length = readUnsignedLeb128();
+		BigInteger[] bigs = new BigInteger[length];
+		for (int i = 0; i < length; i++) {
+			bigs[i] = readUInt64();
+		}
+
+		return bigs;
+	}
+
+	public float[] readFloat32Array() throws IOException {
+		int length = readUnsignedLeb128();
+		float[] floats = new float[length];
+		for (int i = 0; i < length; i++) {
+			floats[i] = readFloat32();
+		}
+
+		return floats;
+	}
+
+	public double[] readFloat64Array() throws IOException {
+		int length = readUnsignedLeb128();
+		double[] doubles = new double[length];
+		for (int i = 0; i < length; i++) {
+			doubles[i] = readFloat64();
+		}
+
+		return doubles;
+	}
+
+	public UUID readUUID() throws IOException {
+		byte[] array = new byte[16];
+		readBytes(array);
+
+		ByteBuffer bb = ByteBuffer.wrap(array).order(ByteOrder.LITTLE_ENDIAN);
+		return new UUID(bb.getLong(), bb.getLong());
+	}
+
+	@Override
+	public void close() throws IOException {
+		in.close();
+	}
+}

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
@@ -65,7 +65,7 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 		return in.read();
 	}
 
-	public boolean isNull() throws IOException {
+	public boolean readIsNull() throws IOException {
 		int value = readByte();
 		if (value == -1)
 			throw new EOFException();

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
@@ -23,7 +23,7 @@ public class ClickHouseRowBinaryStream {
     private static final int U_INT8_MAX = (1 << 8) - 1;
     private static final int U_INT16_MAX = (1 << 16) - 1;
     private static final long U_INT32_MAX = (1L << 32) - 1;
-    private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
+    protected static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
 
     private final LittleEndianDataOutputStream out;
     private final TimeZone timeZone;

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
@@ -1,0 +1,96 @@
+package ru.yandex.clickhouse.util;
+
+import com.google.common.primitives.UnsignedLong;
+import org.testng.annotations.Test;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.testng.Assert.assertEquals;
+
+public class ClickHouseRowBinaryInputStreamTest {
+
+	@Test
+	public void testUInt8() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{1, 0, 1, 0, -1, -128});
+
+		assertEquals(input.readBoolean(), true);
+		assertEquals(input.readBoolean(), false);
+		assertEquals(input.readUInt8(), 1);
+		assertEquals(input.readUInt8(), 0);
+		assertEquals(input.readUInt8(), 255);
+		assertEquals(input.readUInt8(), 128);
+	}
+
+	@Test
+	public void testUInt8AsByte() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{1, 0, 1, 0, -1, -128});
+
+		assertEquals(input.readUInt8AsByte(), (byte) 1);
+		assertEquals(input.readUInt8AsByte(), (byte) 0);
+		assertEquals(input.readUInt8AsByte(), (byte) 1);
+		assertEquals(input.readUInt8AsByte(), (byte) 0);
+		assertEquals(input.readUInt8AsByte(), (byte) 255);
+		assertEquals(input.readUInt8AsByte(), (byte) 128);
+	}
+
+	@Test
+	public void testUInt16() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{0, 0, -1, -1, 0, -128});
+
+		assertEquals(input.readUInt16(), 0);
+		assertEquals(input.readUInt16(), 65535);
+		assertEquals(input.readUInt16(), 32768);
+	}
+
+	@Test
+	public void testUInt16AsShort() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{0, 0, -1, -1, 0, -128});
+
+		assertEquals(input.readUInt16AsShort(), (short) 0);
+		assertEquals(input.readUInt16AsShort(), (short) 65535);
+		assertEquals(input.readUInt16AsShort(), (short) 32768);
+	}
+
+
+	@Test
+	public void testFloat64() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{0, 0, 0, 0, 0, 0, -8, 127});
+
+		assertEquals(input.readFloat64(), Double.NaN);
+	}
+
+	@Test
+	public void testUInt64() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1});
+
+		assertEquals(input.readUInt64AsUnsignedLong(), UnsignedLong.valueOf(0));
+		assertEquals(input.readUInt64AsUnsignedLong(), UnsignedLong.valueOf("18446744073709551615"));
+	}
+
+	@Test
+	public void testUInt64AsLong() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1});
+
+		assertEquals(input.readUInt64AsLong(), 0);
+		assertEquals(input.readUInt64AsLong(), UnsignedLong.valueOf("18446744073709551615").longValue());
+	}
+
+
+	@Test
+	public void testOne() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{5, 97, 46, 98, 46, 99, 123, 20, -82, 71, -31, 26, 69, 64, 34, 87, -13, 88, 120, 67, 48, 116, -13, 88});
+
+		assertEquals(input.readString(), "a.b.c");
+		assertEquals(input.readFloat64(), 42.21);
+		assertEquals(input.readUInt32(), 1492342562L);
+		assertEquals(input.readDate(), new Date(117, 3, 16));
+		assertEquals(input.readUInt32(), 1492350000L);
+	}
+
+	private ClickHouseRowBinaryInputStream prepareStream(byte[] input) {
+		return new ClickHouseRowBinaryInputStream(new ByteArrayInputStream(input), TimeZone.getTimeZone("ETC"), new ClickHouseProperties());
+	}
+}


### PR DESCRIPTION
I've added ClickHouseStatement.executeQueryClickhouseRowBinaryStream methods which return a ClickHouseRowBinaryInputStream to parse result. I've reused integration test in RowBinaryStreamTest.

A quick benchmark shows a performance gain lower than what I expected, maybe because of the little endian to big endian conversion. It also varies depending if the client code runs on the same machine as Clickhouse server.
