### PR TITLE
Enable to get a bound statement in ClickHousePreparedStatement

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatement.java
@@ -25,4 +25,6 @@ public interface ClickHousePreparedStatement extends PreparedStatement, ClickHou
     ResultSet executeQuery(Map<ClickHouseQueryParam, String> additionalDBParams, List<ClickHouseExternalData> externalData) throws SQLException;
 
     int[] executeBatch(Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
+
+    String toString();
 }

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatement.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatement.java
@@ -26,5 +26,5 @@ public interface ClickHousePreparedStatement extends PreparedStatement, ClickHou
 
     int[] executeBatch(Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException;
 
-    String toString();
+    String asSql();
 }

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -607,4 +607,12 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
         return null;
     }
 
+    @Override
+    public String toString () {
+        try {
+            return buildSql();
+        } catch (SQLException e) {
+            return sql;
+        }
+    }
 }

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -608,7 +608,7 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
     }
 
     @Override
-    public String toString () {
+    public String asSql() {
         try {
             return buildSql();
         } catch (SQLException e) {

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -328,4 +328,17 @@ public class ClickHousePreparedStatementTest {
         Assert.assertEquals(rs.getTime(1), Time.valueOf("13:37:42"));
     }
 
+    @Test
+    public void testToString() throws Exception {
+        String unbindedStatement = "SELECT test.example WHERE id IN (?, ?)";
+        PreparedStatement statement = connection.prepareStatement(unbindedStatement);
+        Assert.assertEquals(statement.toString(), unbindedStatement);
+
+        statement.setInt(1, 123);
+        Assert.assertEquals(statement.toString(), unbindedStatement);
+
+        statement.setInt(2, 456);
+        Assert.assertEquals(statement.toString(), "SELECT test.example WHERE id IN (123, 456)");
+    }
+
 }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -329,16 +329,17 @@ public class ClickHousePreparedStatementTest {
     }
 
     @Test
-    public void testToString() throws Exception {
+    public void testAsSql() throws Exception {
         String unbindedStatement = "SELECT test.example WHERE id IN (?, ?)";
-        PreparedStatement statement = connection.prepareStatement(unbindedStatement);
-        Assert.assertEquals(statement.toString(), unbindedStatement);
+        ClickHousePreparedStatement statement = (ClickHousePreparedStatement)
+            connection.prepareStatement(unbindedStatement);
+        Assert.assertEquals(statement.asSql(), unbindedStatement);
 
         statement.setInt(1, 123);
-        Assert.assertEquals(statement.toString(), unbindedStatement);
+        Assert.assertEquals(statement.asSql(), unbindedStatement);
 
         statement.setInt(2, 456);
-        Assert.assertEquals(statement.toString(), "SELECT test.example WHERE id IN (123, 456)");
+        Assert.assertEquals(statement.asSql(), "SELECT test.example WHERE id IN (123, 456)");
     }
 
 }


### PR DESCRIPTION
I have implemented `ClickHousePreparedStatement.toString()`.
This method returns bound statement when `buildSql()` succeeds, otherwise unbound statement.