### PR TITLE
Implement query timeout at the statement level

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -726,6 +726,9 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
             params.put(ClickHouseQueryParam.MAX_RESULT_ROWS, String.valueOf(maxRows));
             params.put(ClickHouseQueryParam.RESULT_OVERFLOW_MODE, "break");
         }
+        if(queryTimeout > 0) {
+            params.put(ClickHouseQueryParam.MAX_EXECUTION_TIME, String.valueOf(queryTimeout));
+        }
     }
 
 

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -67,6 +67,8 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     private int currentUpdateCount = -1;
 
     private int queryTimeout;
+    
+    private boolean isQueryTimeoutSet = false;
 
     private int maxRows;
 
@@ -282,6 +284,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     @Override
     public void setQueryTimeout(int seconds) throws SQLException {
         queryTimeout = seconds;
+        isQueryTimeoutSet = true;
     }
 
     @Override
@@ -726,7 +729,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
             params.put(ClickHouseQueryParam.MAX_RESULT_ROWS, String.valueOf(maxRows));
             params.put(ClickHouseQueryParam.RESULT_OVERFLOW_MODE, "break");
         }
-        if(queryTimeout > 0) {
+        if(isQueryTimeoutSet) {
             params.put(ClickHouseQueryParam.MAX_EXECUTION_TIME, String.valueOf(queryTimeout));
         }
     }

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -62,6 +62,22 @@ public class ClickHouseStatementTest {
     }
 
     @Test
+    public void testMaxExecutionTime() throws Exception {
+        ClickHouseProperties properties = new ClickHouseProperties();
+        properties.setMaxExecutionTime(20);
+        ClickHouseStatementImpl statement = new ClickHouseStatementImpl(HttpClientBuilder.create().build(), null,
+                properties, ResultSet.TYPE_FORWARD_ONLY);
+        URI uri = statement.buildRequestUri(null, null, null, null, false);
+        String query = uri.getQuery();
+        assertTrue(query.contains("max_execution_time=20"), "max_execution_time param is missing in URL");
+        
+        statement.setQueryTimeout(10);
+        uri = statement.buildRequestUri(null, null, null, null, false);
+        query = uri.getQuery();
+        assertTrue(query.contains("max_execution_time=10"), "max_execution_time param is missing in URL");
+    }
+    
+    @Test
     public void testMaxMemoryUsage() throws Exception {
         ClickHouseProperties properties = new ClickHouseProperties();
         properties.setMaxMemoryUsage(41L);


### PR DESCRIPTION
Currently, the method `setQueryTimeout` at the Statement level does nothing (it comes from the JDBC interface)

Only the `setMaxExecutionTime` defined at the `ClickHouseProperties` class is currently implemented.

I change that, for having the timeout defined (if exist) at the statement level to overwrite the one at the properties level, even if it is a 0 (no timeout).

I also add the corresponding tests.