### PR TITLE
Batch rows should be cleared on clear batch. 

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -153,6 +153,11 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
     }
 
     @Override
+    public void clearBatch() throws SQLException {
+        batchRows.clear();
+    }
+
+    @Override
     public ResultSet executeQuery(Map<ClickHouseQueryParam, String> additionalDBParams) throws SQLException {
         return super.executeQuery(buildSql(), additionalDBParams);
     }


### PR DESCRIPTION
Will have memory leak otherwise if clickhouse server is down