### PR TITLE
#307 provide a way to build values for IN clause

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
@@ -134,18 +134,17 @@ public class ClickHouseArrayUtil {
         return builder.build();
     }
 
-    public static String toString(Collection collection) {
-        return toString(collection, true);
-    }
-
     /**
      * Convert collection to its ClickHouse-string representation.
      *
      * @param collection the collection to transform
-     * @param escape     enable or disable escaping of the collection elements
      */
-    public static String toString(Collection collection, boolean escape) {
-        return toString(collection.toArray(), escape);
+    public static String toString(Collection collection) {
+        ArrayBuilder builder = new ArrayBuilder(needQuote(collection.toArray()), false, false);
+        for (Object value : collection) {
+            builder.append(value);
+        }
+        return builder.build();
     }
 
     private static boolean needQuote(Object[] objects) {
@@ -163,13 +162,21 @@ public class ClickHouseArrayUtil {
         private final StringBuilder builder = new StringBuilder();
         private final boolean quote;
         private final boolean explicitEscape;
+        private final boolean wrapAsArray;
         private int size = 0;
         private boolean built = false;
 
         private ArrayBuilder(boolean quote, boolean explicitEscape) {
+            this(quote, explicitEscape, true);
+        }
+
+        private ArrayBuilder(boolean quote, boolean explicitEscape, boolean wrapAsArray) {
             this.quote = quote;
             this.explicitEscape = explicitEscape;
-            builder.append('[');
+            this.wrapAsArray = wrapAsArray;
+            if (wrapAsArray) {
+                builder.append('[');
+            }
         }
 
         private ArrayBuilder append(Object value) {
@@ -198,7 +205,9 @@ public class ClickHouseArrayUtil {
 
         private String build() {
             if (!built) {
-                builder.append(']');
+                if (wrapAsArray) {
+                    builder.append(']');
+                }
                 built = false;
             }
             return builder.toString();

--- a/src/test/java/ru/yandex/clickhouse/integration/ArrayTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ArrayTest.java
@@ -1,5 +1,15 @@
 package ru.yandex.clickhouse.integration;
 
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import ru.yandex.clickhouse.ClickHouseArray;
+import ru.yandex.clickhouse.ClickHouseDataSource;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
 import java.math.BigInteger;
 import java.sql.Array;
 import java.sql.Connection;
@@ -8,19 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Arrays;
-
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
-import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
-import ru.yandex.clickhouse.ClickHouseArray;
-import ru.yandex.clickhouse.ClickHouseDataSource;
-import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import static org.testng.Assert.assertEquals;
 
@@ -100,11 +98,11 @@ public class ArrayTest {
 
         statement = connection.prepareStatement(insertSql);
 
-        statement.setObject(1, new ArrayList<Object>(Arrays.asList(4294967286L, 4294967287L)));
-        statement.setObject(2, new ArrayList<Object>(Arrays.asList(
+        statement.setObject(1, new Long[] {4294967286L, 4294967287L});
+        statement.setObject(2, new BigInteger[] {
                 new BigInteger("18446744073709551606"),
-                new BigInteger("18446744073709551607"))));
-        statement.setObject(3, new ArrayList<Object>(Arrays.asList(1.23, 4.56)));
+                new BigInteger("18446744073709551607")});
+        statement.setObject(3, new Double[] {1.23, 4.56});
         statement.execute();
 
         Statement select = connection.createStatement();

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.UUID;
 
 import com.google.common.io.BaseEncoding;
@@ -378,6 +379,17 @@ public class ClickHousePreparedStatementTest {
 
         statement.setInt(2, 456);
         Assert.assertEquals(statement.asSql(), "SELECT test.example WHERE id IN (123, 456)");
+    }
+
+    @Test
+    public void testInClause() throws Exception {
+        String unbindedStatement = "SELECT test.example WHERE id IN (?)";
+        ClickHousePreparedStatement statement = (ClickHousePreparedStatement)
+                connection.prepareStatement(unbindedStatement);
+        Assert.assertEquals(statement.asSql(), unbindedStatement);
+
+        statement.setObject(1, Arrays.asList(123, 456));
+        Assert.assertEquals(statement.asSql(), "SELECT test.example WHERE id IN (123,456)");
     }
 
     @Test

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
@@ -87,110 +87,110 @@ public class ClickHouseArrayUtilTest {
     @Test
     public void testCollectionToString() throws Exception {
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", "b"))),
+                ClickHouseArrayUtil.toString(new String[] {"a", "b"}),
                 "['a','b']"
         );
 
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", "'b\t"))),
+                ClickHouseArrayUtil.toString(new String[] {"a", "'b\t"}),
                 "['a','\\'b\\t']"
         );
 
         // https://github.com/yandex/clickhouse-jdbc/issues/283
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("\\xEF\\xBC", "\\x3C\\x22"))), // quote == true
+                ClickHouseArrayUtil.toString(new String[] {"\\xEF\\xBC", "\\x3C\\x22"}), // quote == true
                 "['\\\\xEF\\\\xBC','\\\\x3C\\\\x22']"
         );
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("\\xEF\\xBC", "\\x3C\\x22")), false),
+                ClickHouseArrayUtil.toString(new String[] {"\\xEF\\xBC", "\\x3C\\x22"}, false),
                 "['\\xEF\\xBC','\\x3C\\x22']"
         );
 
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, 42))),
+                ClickHouseArrayUtil.toString(new Integer[] {21, 42}),
                 "[21,42]"
         );
 
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, 42))),
+                ClickHouseArrayUtil.toString(new Integer[] {21, 42}),
                 "[21,42]"
         );
 
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(0.1, 1.2))),
+                ClickHouseArrayUtil.toString(new Double[] {0.1, 1.2}),
                 "[0.1,1.2]"
         );
 
         Assert.assertEquals(
-                ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList('a', 'b'))),
+                ClickHouseArrayUtil.toString(new Character[]{'a', 'b'}),
                 "['a','b']"
         );
 
         ArrayList<Object> arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(1, 2)));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(3, 4)));
+        arrayOfArrays.add(new Integer[] {1, 2});
+        arrayOfArrays.add(new Integer[] {3, 4});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[[1,2],[3,4]]"
         );
 
         arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(1.1, 2.4)));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(3.9, 4.16)));
+        arrayOfArrays.add(new Double[] {1.1, 2.4});
+        arrayOfArrays.add(new Double[] {3.9, 4.16});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[[1.1,2.4],[3.9,4.16]]"
         );
 
         arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList("a", "b")));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList("c", "'d\t")));
+        arrayOfArrays.add(new String[] {"a", "b"});
+        arrayOfArrays.add(new String[] {"c", "'d\t"});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[['a','b'],['c','\\'d\\t']]"
         );
 
         arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('a', 'b')));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', 'd')));
+        arrayOfArrays.add(new Character[] {'a', 'b'});
+        arrayOfArrays.add(new Character[] {'c', 'd'});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[['a','b'],['c','d']]"
         );
 
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(21, null))),
+            ClickHouseArrayUtil.toString(new Integer[] {21, null}),
             "[21,NULL]"
         );
 
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, 42))),
+            ClickHouseArrayUtil.toString(new Integer[] {null, 42}),
             "[NULL,42]"
         );
 
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList("a", null))),
+            ClickHouseArrayUtil.toString(new String[] {"a", null}),
             "['a',NULL]"
         );
 
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(new ArrayList<Object>(Arrays.asList(null, "b"))),
+            ClickHouseArrayUtil.toString(new String[] {null, "b"}),
             "[NULL,'b']"
         );
 
         arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(null, 'b')));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', 'd')));
+        arrayOfArrays.add(new Character[] {null, 'b'});
+        arrayOfArrays.add(new Character[] {'c', 'd'});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[[NULL,'b'],['c','d']]"
         );
 
         arrayOfArrays = new ArrayList<Object>();
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList(null, 'b')));
-        arrayOfArrays.add(new ArrayList<Object>(Arrays.asList('c', null)));
+        arrayOfArrays.add(new Character[] {null, 'b'});
+        arrayOfArrays.add(new Character[] {'c', null});
         Assert.assertEquals(
-            ClickHouseArrayUtil.toString(arrayOfArrays),
+            ClickHouseArrayUtil.toString(arrayOfArrays.toArray()),
             "[[NULL,'b'],['c',NULL]]"
         );
     }


### PR DESCRIPTION
Currently clickhouse jdbc driver doesn't provide any way to specify dynamic number of values for IN clause. For example, 

```
List<Integer> list = Arrays.asList(1,2,3,4,5);
statement.setObject(1, list);
```
for `where id in (?)` will always build an array:

`WHERE id IN ([1,2,3,4,5])`

while result should be:

`WHERE id IN (1,2,3,4,5)`

Fixes https://github.com/yandex/clickhouse-jdbc/issues/307.


This PR breaks back compatibility for those who uses `setObject` method with list. They need to use array instead of the list in order to preserve previous behaviour.