### PR TITLE
#312 Allow CSV format in select clause

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseFormat.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseFormat.java
@@ -4,7 +4,18 @@ package ru.yandex.clickhouse.util;
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
  */
 public enum ClickHouseFormat {
-    TabSeparated,
-    RowBinary,
-    Native
+
+    TabSeparatedWithNamesAndTypes("TabSeparatedWithNamesAndTypes"),
+    TabSeparated("TabSeparated"),
+    RowBinary("RowBinary"),
+    JSONCompact("JSONCompact"),
+    Native("Native"),
+    CSVWithNames("CSVWithNames");
+
+    public final String name;
+
+    ClickHouseFormat(String name) {
+        this.name = name;
+    }
+
 }

--- a/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHouseStatementTest.java
@@ -39,6 +39,12 @@ public class ClickHouseStatementTest {
 
         String sql6 = " show ololo FROM ololoed;";
         assertEquals("show ololo FROM ololoed FORMAT TabSeparatedWithNamesAndTypes;", ClickHouseStatementImpl.clickhousifySql(sql6));
+
+        String sql7 = " show ololo FROM ololoed FORMAT CSVWithNames;";
+        assertEquals("show ololo FROM ololoed FORMAT CSVWithNames;", ClickHouseStatementImpl.clickhousifySql(sql7));
+
+        String sql8 = " show ololo FROM ololoed FORMAT CSVWithNames";
+        assertEquals("show ololo FROM ololoed FORMAT CSVWithNames", ClickHouseStatementImpl.clickhousifySql(sql8));
     }
 
     @Test


### PR DESCRIPTION
This PR partially fixes https://github.com/yandex/clickhouse-jdbc/issues/312 and prepares the code for further refactoring/improvements (make clickhouse result set aware of `Format` type).

This change is required in order to allow in format like `CSV` that will allow (after further fixes) to export full csv from select clause.