### PR TITLE
Use latest ClickHouse server version for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ jdk:
 services:
   - docker
 before_script:
-  - docker run -e TZ=Europe/Moscow -d -p 127.0.0.1:8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:1.1.54276
+  - docker run -e TZ=Europe/Moscow -d -p 127.0.0.1:8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:latest


### PR DESCRIPTION
Perhaps you want to use a different "reference" version, but we should at least test with 18.x, I think. Issue #319 