### PR TITLE
Check class of ResultSet.getObject versus meta data #300

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,7 +91,7 @@ public class TypeUtils {
 
     public static String getArrayElementTypeName(String clickhouseType) {
         if (!isArray(clickhouseType)) {
-            throw new IllegalArgumentException("not an array");
+            throw new IllegalArgumentException("not an array " + clickhouseType);
         }
 
         return clickhouseType.substring("Array(".length(), clickhouseType.length() - 1);
@@ -144,8 +145,10 @@ public class TypeUtils {
             case Types.ARRAY:
                 Class elementType = toClass(elementSqltype, isUnsigned);
                 return Array.newInstance(elementType, 0).getClass();
+            case Types.OTHER:
+                return UUID.class;
             default:
-                throw new UnsupportedOperationException("Sql type " + sqlType + "is not supported");
+                throw new UnsupportedOperationException("Sql type " + sqlType + " is not supported");
         }
     }
 

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.Types;
 import java.util.TimeZone;
 
@@ -16,12 +17,14 @@ import ru.yandex.clickhouse.ClickHouseStatement;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 
 public class ClickHouseResultSetTest {
+
     @DataProvider(name = "longArrays")
     public Object[][] longArrays() {
         return new Object[][]{
@@ -302,7 +305,139 @@ public class ClickHouseResultSetTest {
         assertEquals(rs.getMetaData().getPrecision(1), 38);
     }
 
-    protected ClickHouseResultSet buildResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
+    @Test
+    public void testClassNamesObjects() throws Exception {
+        String testData = ClickHouseTypesTestData.buildTestString();
+        ByteArrayInputStream is = new ByteArrayInputStream(testData.getBytes("UTF-8"));
+        ResultSet rs = buildResultSet(is, testData.length(), "db", "table", false, null,
+            TimeZone.getTimeZone("UTC"), props);
+        rs.next();
+        ResultSetMetaData meta = rs.getMetaData();
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            String typeName = meta.getColumnTypeName(i);
+            String className = null;
+            try {
+                className = meta.getColumnClassName(i);
+            } catch (Exception e) {
+                fail("Unable to determine class name for " + typeName, e);
+            }
+            Class<?> clazz = Class.forName(className);
+            assertNotNull(
+                clazz,
+                "Class not available. class name: " + className + ", type name: " + typeName);
+            Object o = rs.getObject(i);
+            if (o == null && meta.isNullable(i) > 0) {
+                continue;
+            }
+            assertNotNull(
+                o,
+                "Object null. class name: " + className + ", type name: " + typeName);
+            assertTrue(
+                clazz.isAssignableFrom(rs.getObject(i).getClass()),
+                "Class mismatch. class name: " + className + ", type name: " + typeName +
+                    " object class: " + o.getClass().getCanonicalName());
+        }
+    }
+
+    private ClickHouseResultSet buildResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
     	return new ClickHouseResultSet(is, bufferSize, db, table, usesWithTotals, statement, timezone, properties);
+    }
+
+    private static enum ClickHouseTypesTestData {
+
+        // SELECT name FROM system.data_type_families WHERE alias_to <> '' ORDER BY name ASC
+
+        // AggregateFunction
+        Array("Array(String)", "[foo, bar]", false, false),
+        Date("Date", "2019-03-03", false, true),
+        DateTime("DateTime", "2019-03-03 13:37:42", false, true),
+        Decimal("Decimal(12,2)", "42.23", false, true),
+        // Decimal128
+        // Decimal32
+        // Decimal64
+        Enum16("Enum16('foo'=0,'bar'=1)", "FOO", false, true),
+        Enum8("Enum8('foo'=0,'bar'=1)", "BAR", false, true),
+        FixedString("FixedString(3)", "BAZ", false, true),
+        Float32("Float32", "42.23", false, true),
+        Float64("Float64", "42.23", false, true),
+        IPv4("IPv4", "127.0.0.1", false, true),
+        IPv6("IPv6", "::1", false, true),
+        Int16("Int16", "1337", false, true),
+        Int32("Int32", "1337", false, true),
+        Int64("Int64", "1337", false, true),
+        Int8("Int8", "42", false, true),
+        // IntervalDay
+        // IntervalHour
+        // IntervalMinute
+        // IntervalMonth
+        // IntervalQuarter
+        // IntervalSecond
+        // IntervalWeek
+        // IntervalYear
+        // LowCardinality
+        // Nested
+        // Nothing
+        // Nullable
+        String("String", "foo", true, true),
+        Tuple("Tuple(UInt8, String)", "(42, 'foo')", false, true),
+        UInt16("UInt16", "42", false, true),
+        UInt32("UInt32", "23", false, true),
+        UInt64("UInt64", "1337", false, true),
+        UInt8("UInt8", "1", false, true),
+        UUID("UUID", "61f0c404-5cb3-11e7-907b-a6006ad3dba0", true, true);
+
+        private final String typeName;
+        private final String serializedValue;
+        private final boolean lowCardinalityCandidate;
+        private final boolean nullableCandidate;
+
+        ClickHouseTypesTestData(String typeName, String serializedValue,
+            boolean lowCardinalityCandidate, boolean nullableCandidate)
+        {
+            this.typeName = typeName;
+            this.serializedValue = serializedValue;
+            this.lowCardinalityCandidate = lowCardinalityCandidate;
+            this.nullableCandidate = nullableCandidate;
+        }
+
+        private static String buildTestString() {
+            StringBuilder sb = new StringBuilder();
+            // row 1: column names
+            for (ClickHouseTypesTestData t : values()) {
+                sb.append(t.typeName)
+                  .append("\t");
+                if (t.nullableCandidate) {
+                    sb.append("Nullable(")
+                      .append(t.typeName)
+                      .append(')')
+                      .append("\t");
+                }
+                if (t.lowCardinalityCandidate) {
+                    sb.append("LowCardinality(")
+                      .append(t.typeName)
+                      .append(')')
+                      .append("\t");
+                }
+            }
+            sb.replace(sb.length(), sb.length(), "\n");
+
+            // row 2: type names
+            sb.append(sb.substring(0, sb.length()));
+
+            // row 3 : example data
+            for (ClickHouseTypesTestData t : values()) {
+                sb.append(t.serializedValue)
+                  .append("\t");
+                if (t.nullableCandidate) {
+                    sb.append("\\N\t");
+                }
+                if (t.lowCardinalityCandidate) {
+                    sb.append(t.serializedValue)
+                      .append("\t");
+                }
+            }
+            sb.replace(sb.length(), sb.length(), "\n");
+            return sb.toString();
+        }
     }
 }

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseScrollableResultSetTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseScrollableResultSetTest.java
@@ -1,36 +1,39 @@
 package ru.yandex.clickhouse.response;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import ru.yandex.clickhouse.ClickHouseStatement;
-import ru.yandex.clickhouse.settings.ClickHouseProperties;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.ResultSet;
 import java.util.TimeZone;
 
-import static org.testng.Assert.*;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import ru.yandex.clickhouse.ClickHouseStatement;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
 public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
-	
+
     ClickHouseProperties props = new ClickHouseProperties();
     TimeZone tz = TimeZone.getDefault();
-    
 
+
+    @Override
     @DataProvider(name = "longArrays")
     public Object[][] longArrays() {
         return new Object[][]{
                 {"[0]", new long[]{0}},
-                {"[333000111222,1024,-8521551,9223372036854775807,-9223372036854775808]", 
+                {"[333000111222,1024,-8521551,9223372036854775807,-9223372036854775808]",
                 	new long[]{333000111222L, 1024, -8521551,9223372036854775807L,-9223372036854775808L}},
                 {"[]", new long[]{}},
         };
     }
-    
+
+    @Override
     @Test
     public void testIsLast() throws Exception {
         String response =
@@ -42,14 +45,14 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
         ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
 
         ResultSet rs = buildResultSet(is, 1024, "db", "table", false, null, null, props);
-        
+
         rs.next();
         assertFalse(rs.isLast());
         rs.next();
         assertTrue(rs.isLast());
         assertFalse(rs.next());
     }
-    
+
     @Test
     public void testPrevious() throws Exception {
         String response =
@@ -69,12 +72,12 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
               rs.next();
               assertEquals("there.com", rs.getString(1));
               assertEquals(49302091L, rs.getLong(2));
-              
+
               rs.previous();
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
     }
-    
+
     @Test
     public void testAbsolute() throws Exception {
         String response =
@@ -90,19 +93,19 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
               rs.absolute(2);
               assertEquals("there.com", rs.getString(1));
               assertEquals(49302091L, rs.getLong(2));
-              
+
               rs.absolute(1);
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               rs.absolute(-1);
               assertEquals("there.com", rs.getString(1));
               assertEquals(49302091L, rs.getLong(2));
-              
+
               assertTrue(rs.isLast());
-              
+
     }
-    
+
     public void testAbsoluteWithTotal() throws Exception {
         String response = "SiteName\tcount()\n" +
                 "String\tUInt64\n" +
@@ -118,32 +121,32 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
       rs.absolute(2);
       assertEquals("there.com", rs.getString(1));
       assertEquals(49302091L, rs.getLong(2));
-      
+
       rs.absolute(1);
       assertEquals("hello.com", rs.getString(1));
       assertEquals(21209048L, rs.getLong(2));
-      
+
       rs.absolute(-1);
       assertEquals("there.com", rs.getString(1));
       assertEquals(49302091L, rs.getLong(2));
-      
+
       assertTrue(rs.isLast());
-      
+
       assertFalse(rs.absolute(3));
       assertTrue(rs.isAfterLast());
-      
+
       assertFalse(rs.absolute(-3));
       assertTrue(rs.isBeforeFirst());
-      
+
       assertFalse(rs.absolute(0));
       assertTrue(rs.isBeforeFirst());
-      
+
       rs.getTotals();
       assertEquals("", rs.getString(1));
       assertEquals(70511139L, rs.getLong(2));
-              
+
     }
-    
+
     @Test
     public void testRelative() throws Exception {
         String response =
@@ -159,11 +162,11 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
               rs.next();
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               rs.relative(0);
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               rs.relative(1);
               assertEquals("there.com", rs.getString(1));
               assertEquals(49302091L, rs.getLong(2));
@@ -171,12 +174,12 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
               rs.relative(-1);
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               assertFalse(rs.relative(5));
               assertFalse(rs.relative(-5));
-              
+
     }
-    
+
     @Test
     public void testBeforeFirst() throws Exception {
         String response =
@@ -192,19 +195,18 @@ public class ClickHouseScrollableResultSetTest extends ClickHouseResultSetTest {
               rs.next();
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               rs.beforeFirst();
               rs.next();
               assertEquals("hello.com", rs.getString(1));
               assertEquals(21209048L, rs.getLong(2));
-              
+
               rs.afterLast();
               assertFalse(rs.hasNext());
-              
+
     }
-    
-    @Override
-    protected ClickHouseResultSet buildResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
+
+    private ClickHouseResultSet buildResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
     	return new ClickHouseScrollableResultSet(is, bufferSize, db, table, usesWithTotals, statement, timezone, properties);
     }
 }


### PR DESCRIPTION
1. Let's make sure we do not break too much stuff when fiddling with type mappings
2. Add missing UUID mapping (luckily, we do not use `Types.OTHER` for anything else)