### PR TITLE
Issue with quote inside back quotes, or back quotes inside quote in prepared statements

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/PreparedStatementParser.java
+++ b/src/main/java/ru/yandex/clickhouse/PreparedStatementParser.java
@@ -87,7 +87,7 @@ final class PreparedStatementParser  {
                 afterBackSlash = false;
             } else if (c == '\\') {
                 afterBackSlash = true;
-            } else if (c == '\'') {
+            } else if (c == '\'' && !inBackQuotes) {
                 inQuotes = !inQuotes;
                 if (inQuotes) {
                     quotedStart = i;
@@ -95,7 +95,7 @@ final class PreparedStatementParser  {
                     idxStart = quotedStart;
                     idxEnd = i + 1;
                 }
-            } else if (c == '`') {
+            } else if (c == '`' && !inQuotes) {
                 inBackQuotes = !inBackQuotes;
             } else if (!inQuotes && !inBackQuotes) {
                 if (c == '?') {

--- a/src/test/java/ru/yandex/clickhouse/PreparedStatementParserTest.java
+++ b/src/test/java/ru/yandex/clickhouse/PreparedStatementParserTest.java
@@ -376,6 +376,15 @@ public class PreparedStatementParserTest {
         Assert.assertEquals(s.getParts().get(4), ", ");
         Assert.assertEquals(s.getParts().get(5), "");
     }
+    
+    @Test
+    public void testSingleAndBackMixedQuotes() {
+        PreparedStatementParser s = PreparedStatementParser.parse(
+            "SELECT '`' as `'` WHERE 0 = ?");
+        assertMatchParams(new String[][] {{"?"}}, s);
+        Assert.assertEquals(s.getParts().get(0), "SELECT '`' as `'` WHERE 0 = ");
+    }
+
 
     private static void assertMatchParts(String[] expected, PreparedStatementParser stmt) {
         List<String> parts = stmt.getParts();


### PR DESCRIPTION
I get exception when on some specific queries where I have quote inside back quotes (or the opposite). The number of parameters was not well computed by the PrepareStatementImpl class.

This simple change fix the issue here, and I also add a new test.