### PR TITLE
Make sure timezone is initialized

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -82,6 +82,9 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
         if (properties.isUseServerTimeZone() && !Strings.isNullOrEmpty(properties.getUseTimeZone())) {
             throw new IllegalArgumentException(String.format("only one of %s or %s must be enabled", ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE.getKey(), ClickHouseConnectionSettings.USE_TIME_ZONE.getKey()));
         }
+        if (!properties.isUseServerTimeZone() && Strings.isNullOrEmpty(properties.getUseTimeZone())) {
+            throw new IllegalArgumentException(String.format("one of %s or %s must be enabled", ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE.getKey(), ClickHouseConnectionSettings.USE_TIME_ZONE.getKey()));
+        }
         if (properties.isUseServerTimeZone()) {
             ResultSet rs = null;
             try {


### PR DESCRIPTION
Timezone is not initialised if none of `use_server_time_zone` and `use_time_zone` is set.
As consequence client gets parser exception when retrieving dates. See https://youtrack.jetbrains.com/issue/DBE-7776