### PR TITLE
fix BalancedClickhouseDataSource contructor 2nd ClickhouseProperities parameter overwrited with default value, losing the custom settings

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
@@ -9,11 +9,7 @@ import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -33,7 +29,7 @@ public class BalancedClickhouseDataSource implements DataSource {
     private static final Pattern URL_TEMPLATE = Pattern.compile(JDBC_CLICKHOUSE_PREFIX + "" +
             "//([a-zA-Z0-9_:,.-]+)" +
             "(/[a-zA-Z0-9_]+" +
-            "([?][a-zA-Z0-9_]+[=][a-zA-Z0-9_]([&][a-zA-Z0-9_]+[=][a-zA-Z0-9_]+)*)?" +
+            "([?][a-zA-Z0-9_]+[=][a-zA-Z0-9_]+([&][a-zA-Z0-9_]+[=][a-zA-Z0-9_]+)*)?" +
             ")?");
 
     private PrintWriter printWriter;
@@ -77,7 +73,7 @@ public class BalancedClickhouseDataSource implements DataSource {
      * @see #BalancedClickhouseDataSource(String)
      */
     public BalancedClickhouseDataSource(final String url, ClickHouseProperties properties) {
-        this(splitUrl(url), properties.merge(getFromUrl(url)));
+        this(splitUrl(url), properties.merge(getFromUrlWithoutDefault(url)));
     }
 
     private BalancedClickhouseDataSource(final List<String> urls) {
@@ -327,13 +323,17 @@ public class BalancedClickhouseDataSource implements DataSource {
     }
 
     private static ClickHouseProperties getFromUrl(String url) {
+        return new ClickHouseProperties(getFromUrlWithoutDefault(url));
+    }
+
+    private static Properties getFromUrlWithoutDefault(String url) {
         if (StringUtils.isBlank(url))
-            return new ClickHouseProperties();
+            return new Properties();
 
         int index = url.indexOf("?");
         if (index == -1)
-            return new ClickHouseProperties();
+            return new Properties();
 
-        return new ClickHouseProperties(ClickhouseJdbcUrlParser.parseUriQueryPart(url.substring(index + 1), new Properties()));
+        return ClickhouseJdbcUrlParser.parseUriQueryPart(url.substring(index + 1), new Properties());
     }
 }

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -806,4 +806,12 @@ public class ClickHouseProperties {
         return new ClickHouseProperties(properties);
     }
 
+    public ClickHouseProperties merge(Properties other){
+        Properties properties = this.asProperties();
+        for (Map.Entry<Object, Object> entry : other.entrySet())
+            properties.put(entry.getKey(), entry.getValue());
+
+        return new ClickHouseProperties(properties);
+    }
+
 }

--- a/src/test/java/ru/yandex/clickhouse/BalancedClickhouseDataSourceTest.java
+++ b/src/test/java/ru/yandex/clickhouse/BalancedClickhouseDataSourceTest.java
@@ -178,4 +178,37 @@ public class BalancedClickhouseDataSourceTest {
         assertEquals(42, rs.getInt("i"));
     }
 
+    @Test
+    public void testConstructWithClickHouseProperties() {
+        final ClickHouseProperties properties = new ClickHouseProperties();
+        properties.setMaxThreads(3);
+        properties.setSocketTimeout(67890);
+        properties.setPassword("888888");
+        //without connection parameters
+        BalancedClickhouseDataSource dataSource = new BalancedClickhouseDataSource(
+                "jdbc:clickhouse://localhost:8123,127.0.0.1:8123/click", properties);
+        ClickHouseProperties dataSourceProperties = dataSource.getProperties();
+        assertEquals(dataSourceProperties.getMaxThreads().intValue(), 3);
+        assertEquals(dataSourceProperties.getSocketTimeout(), 67890);
+        assertEquals(dataSourceProperties.getPassword(), "888888");
+        assertEquals(dataSourceProperties.getDatabase(), "click");
+        assertEquals(2, dataSource.getAllClickhouseUrls().size());
+        assertEquals(dataSource.getAllClickhouseUrls().get(0), "jdbc:clickhouse://localhost:8123/click");
+        assertEquals(dataSource.getAllClickhouseUrls().get(1), "jdbc:clickhouse://127.0.0.1:8123/click");
+        // with connection parameters
+        dataSource = new BalancedClickhouseDataSource(
+                "jdbc:clickhouse://localhost:8123,127.0.0.1:8123/click?socket_timeout=12345&user=readonly", properties);
+        dataSourceProperties = dataSource.getProperties();
+        assertEquals(dataSourceProperties.getMaxThreads().intValue(), 3);
+        assertEquals(dataSourceProperties.getSocketTimeout(), 12345);
+        assertEquals(dataSourceProperties.getUser(), "readonly");
+        assertEquals(dataSourceProperties.getPassword(), "888888");
+        assertEquals(dataSourceProperties.getDatabase(), "click");
+        assertEquals(2, dataSource.getAllClickhouseUrls().size());
+        assertEquals(dataSource.getAllClickhouseUrls().get(0), "jdbc:clickhouse://localhost:8123/click?socket_timeout" +
+                "=12345&user=readonly");
+        assertEquals(dataSource.getAllClickhouseUrls().get(1), "jdbc:clickhouse://127.0.0" +
+                ".1:8123/click?socket_timeout=12345&user=readonly");
+    }
+
 }

--- a/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
+++ b/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
@@ -116,4 +116,38 @@ public class ClickHousePropertiesTest {
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.INSERT_QUORUM_TIMEOUT), "1000");
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.SELECT_SEQUENTIAL_CONSISTENCY), "1");
     }
+
+    @Test
+    public void mergeClickHousePropertiesTest() {
+        ClickHouseProperties clickHouseProperties1 = new ClickHouseProperties();
+        ClickHouseProperties clickHouseProperties2 = new ClickHouseProperties();
+        clickHouseProperties1.setDatabase("click");
+        clickHouseProperties1.setConnectionTimeout(13000);
+        clickHouseProperties2.setSocketTimeout(15000);
+        clickHouseProperties2.setUser("readonly");
+        final ClickHouseProperties merged = clickHouseProperties1.merge(clickHouseProperties2);
+        // merge equals: clickHouseProperties1 overwrite with clickHouseProperties2's value or default not null value
+        Assert.assertEquals(merged.getDatabase(),"click"); // using properties1, because properties1 not setting and
+        // default value is null
+        Assert.assertEquals(merged.getConnectionTimeout(),ClickHouseConnectionSettings.CONNECTION_TIMEOUT.getDefaultValue());// overwrite with properties2's default value
+        Assert.assertEquals(merged.getSocketTimeout(),15000);// using properties2
+        Assert.assertEquals(merged.getUser(),"readonly"); // using properties2
+    }
+
+    @Test
+    public void mergePropertiesTest() {
+        ClickHouseProperties clickHouseProperties1 = new ClickHouseProperties();
+        Properties properties2 = new Properties();
+        clickHouseProperties1.setDatabase("click");
+        clickHouseProperties1.setMaxThreads(8);
+        clickHouseProperties1.setConnectionTimeout(13000);
+        properties2.put(ClickHouseConnectionSettings.SOCKET_TIMEOUT.getKey(), "15000");
+        properties2.put(ClickHouseQueryParam.DATABASE.getKey(), "house");
+        final ClickHouseProperties merged = clickHouseProperties1.merge(properties2);
+        // merge equals: clickHouseProperties1 overwrite with properties in properties2 not including default value
+        Assert.assertEquals( merged.getDatabase(),"house");// overwrite with properties2
+        Assert.assertEquals(merged.getMaxThreads().intValue(),8);// using properties1
+        Assert.assertEquals(merged.getConnectionTimeout(),13000);// using properties1
+        Assert.assertEquals(merged.getSocketTimeout(),15000);// using properties2
+    }
 }


### PR DESCRIPTION
- fix specified properties in 2nd para of BalancedClickhouseDataSource(url,clickhouseproperties) overwrited with default value
- fix incorrect pattern of multi host jdbc url with connections parameters

**issue reference:**
https://github.com/yandex/clickhouse-jdbc/issues/337