### PR TITLE
improve LogProxy

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/FastByteArrayOutputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/response/FastByteArrayOutputStream.java
@@ -25,7 +25,7 @@ public final class FastByteArrayOutputStream extends OutputStream {
 
     /**
      * Creates a new byte array output stream. The buffer capacity is
-     * initially 32 bytes, though its size increases if necessary.
+     * initially 1024 bytes, though its size increases if necessary.
      */
     public FastByteArrayOutputStream() {
 	this(1024);

--- a/src/main/java/ru/yandex/clickhouse/util/LogProxy.java
+++ b/src/main/java/ru/yandex/clickhouse/util/LogProxy.java
@@ -42,22 +42,31 @@ public class LogProxy<T> implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        String msg =
-            "Call class: " + object.getClass().getName() +
-            "\nMethod: " + method.getName() +
-            "\nObject: " + object +
-            "\nArgs: " + Arrays.toString(args) +
-            "\nInvoke result: ";
-        try {
-            final Object invokeResult = method.invoke(object, args);
-            msg +=  invokeResult;
-            return invokeResult;
-        } catch (InvocationTargetException e) {
-            msg += e.getMessage();
-            throw e.getTargetException();
-        } finally {
-            msg = "==== ClickHouse JDBC trace begin ====\n" + msg + "\n==== ClickHouse JDBC trace end ====";
-            log.trace(msg);
+        if (log.isTraceEnabled()) {
+            String msg =
+                    "Call class: " + object.getClass().getName() +
+                            "\nMethod: " + method.getName() +
+                            "\nObject: " + object +
+                            "\nArgs: " + Arrays.toString(args) +
+                            "\nInvoke result: ";
+            try {
+                final Object invokeResult = method.invoke(object, args);
+                msg +=  invokeResult;
+                return invokeResult;
+            } catch (InvocationTargetException e) {
+                msg += e.getMessage();
+                throw e.getTargetException();
+            } finally {
+                msg = "==== ClickHouse JDBC trace begin ====\n" + msg + "\n==== ClickHouse JDBC trace end ====";
+                log.trace(msg);
+            }
+        } else {
+        	try {
+		        return method.invoke(object, args);
+	        } catch (InvocationTargetException e) {
+		        throw e.getTargetException();
+	        }
         }
+
     }
 }


### PR DESCRIPTION
In production, log levels are often higher than trace, in those cases, it's unnecessary to import variables like `msg `,`invokeResult `