### PR TITLE
ClickHouseUnknownException thrown on Connection refused

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/except/ClickHouseExceptionSpecifier.java
+++ b/src/main/java/ru/yandex/clickhouse/except/ClickHouseExceptionSpecifier.java
@@ -71,7 +71,11 @@ public final class ClickHouseExceptionSpecifier {
             return -1;
         }
 
-        return Integer.parseInt(errorMessage.substring(startIndex + 1, endIndex));
+        try {
+        	return Integer.parseInt(errorMessage.substring(startIndex + 1, endIndex));
+        } catch(NumberFormatException e) {
+        	return -1;
+        }
     }
 
     private static ClickHouseException getException(Throwable cause, String host, int port) {


### PR DESCRIPTION
On some cases, during the opening of a clickhouse connection, if the server is not up and we use the Server Timezone, we could have such error :
ERROR 2019-06-03 15:13:47,001 [main] ClickHouseExceptionSpecifier  - Unsupported ClickHouse error format, please fix ClickHouseExceptionSpecifier, message: Connect to localhost:18123 [localhost/0:0:0:0:0:0:0:1, localhost/127.0.0.1] failed: Connexion refusée (Connection refused), error: For input string: "to localhost:18123 [localhost/0:0:0:0:0:0:0:1"

From what I see, the error parsing of the connection refused is generating a new exception.
