### PR TITLE
Some methods in ResultSet may produce NumberFormatException or NPE

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -444,7 +444,11 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     @Override
     public Time getTime(int columnIndex) throws SQLException {
-        return new Time(getTimestamp(columnIndex).getTime());
+        Timestamp ts = getTimestamp(columnIndex);
+        if (ts == null)
+            return null;
+
+        return new Time(ts.getTime());
     }
 
     @Override
@@ -491,6 +495,9 @@ public class ClickHouseResultSet extends AbstractResultSet {
     /////////////////////////////////////////////////////////
 
     private static byte toByte(ByteFragment value) {
+        if (value.isNull()) {
+            return 0;
+        }
         return Byte.parseByte(value.asString());
     }
 

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
@@ -325,6 +325,7 @@ public class ClickHouseResultSetTest {
         assertEquals("bar", s[1]);
     }
 
+    @Test
     public void testClassNamesObjects() throws Exception {
         String testData = ClickHouseTypesTestData.buildTestString();
         ByteArrayInputStream is = new ByteArrayInputStream(testData.getBytes("UTF-8"));

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultSetTest.java
@@ -359,6 +359,60 @@ public class ClickHouseResultSetTest {
         }
     }
 
+    /**
+     * By jdbc specification
+     *
+     * If the value is SQL <code>NULL</code>, the value returned is <code>0</code>
+     *
+     * {@link java.sql.ResultSet#getByte(int)}
+     * {@link java.sql.ResultSet#getShort(int)}
+     * {@link java.sql.ResultSet#getInt(int)}
+     * {@link java.sql.ResultSet#getLong(int)}
+     * {@link java.sql.ResultSet#getFloat(int)}
+     * {@link java.sql.ResultSet#getDouble(int)}
+     *
+     * If the value is SQL <code>NULL</code>, the value returned is <code>null</code>
+     *
+     * {@link java.sql.ResultSet#getBigDecimal(int)}
+     * {@link java.sql.ResultSet#getTime(int)}
+     * {@link java.sql.ResultSet#getDate(int)}
+     * {@link java.sql.ResultSet#getTimestamp(int)}
+     * {@link java.sql.ResultSet#getURL(int)} unsupported now
+     * {@link java.sql.ResultSet#getAsciiStream(int)} unsupported now
+     */
+    @Test
+    public void testNulls() throws Exception {
+        String response =
+                "Type\n" +
+                        "Nullable(Int8)\n" +
+                        "\\N\n";
+
+        ByteArrayInputStream is = new ByteArrayInputStream(response.getBytes("UTF-8"));
+
+        ResultSet rs = buildResultSet(is, 1024, "db", "table", false, null, null, props);
+
+        rs.next();
+        //0
+        assertEquals(0, rs.getByte(1));
+        assertEquals(0, rs.getShort(1));
+        assertEquals(0, rs.getInt(1));
+        assertEquals(0, rs.getLong(1));
+        assertEquals((float) 0, rs.getFloat(1));
+        assertEquals((double)0, rs.getDouble(1));
+
+        //null
+        assertNull(rs.getBigDecimal(1));
+        assertNull(rs.getTime(1));
+        assertNull(rs.getDate(1));
+        assertNull(rs.getTimestamp(1));
+
+        //unsupported now
+        //assertNull(rs.getURL(1));
+        //assertNull(rs.getAsciiStream(1));
+
+        assertFalse(rs.next());
+    }
+
     protected ClickHouseResultSet buildResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
     	return new ClickHouseResultSet(is, bufferSize, db, table, usesWithTotals, statement, timezone, properties);
     }


### PR DESCRIPTION
Some methods in ResultSet may produce NumberFormatException or NPE. 
This bugs was found when using jOOQ:
```
Caused by: java.lang.NumberFormatException: For input string: "\N"
    at java.lang.NumberFormatException.forInputString (NumberFormatException.java:65)
    at java.lang.Integer.parseInt (Integer.java:580)
    at java.lang.Byte.parseByte (Byte.java:149)
    at java.lang.Byte.parseByte (Byte.java:175)
    at ru.yandex.clickhouse.response.ClickHouseResultSet.toByte (ClickHouseResultSet.java:494)
    at ru.yandex.clickhouse.response.ClickHouseResultSet.getByte (ClickHouseResultSet.java:398)
    at org.jooq.tools.jdbc.DefaultResultSet.getByte (DefaultResultSet.java:124)
    at org.jooq.impl.CursorImpl$CursorResultSet.getByte (CursorImpl.java:748)
    at org.jooq.impl.DefaultBinding$DefaultByteBinding.get0 (DefaultBinding.java:1626)
    at org.jooq.impl.DefaultBinding$DefaultByteBinding.get0 (DefaultBinding.java:1598)
    at org.jooq.impl.DefaultBinding$AbstractBinding.get (DefaultBinding.java:775)
    at org.jooq.impl.CursorImpl$CursorIterator$CursorRecordInitialiser.setValue (CursorImpl.java:1771)
    at org.jooq.impl.CursorImpl$CursorIterator$CursorRecordInitialiser.operate (CursorImpl.java:1740)
    at org.jooq.impl.CursorImpl$CursorIterator$CursorRecordInitialiser.operate (CursorImpl.java:1705)
    at org.jooq.impl.RecordDelegate.operate (RecordDelegate.java:125)
    at org.jooq.impl.CursorImpl$CursorIterator.fetchNext (CursorImpl.java:1669)
    at org.jooq.impl.CursorImpl$CursorIterator.hasNext (CursorImpl.java:1636)
    at org.jooq.impl.CursorImpl.fetchNext (CursorImpl.java:408)
    at org.jooq.impl.CursorImpl.fetch (CursorImpl.java:394)
    at org.jooq.impl.CursorImpl.fetch (CursorImpl.java:301)
    at org.jooq.impl.AbstractResultQuery.execute (AbstractResultQuery.java:297)
    at org.jooq.impl.AbstractQuery.execute (AbstractQuery.java:350)
    at org.jooq.impl.AbstractResultQuery.fetch (AbstractResultQuery.java:323)
    at org.jooq.impl.AbstractResultQuery.fetchInto (AbstractResultQuery.java:1445)
    at org.jooq.impl.SelectImpl.fetchInto (SelectImpl.java:3746)
```

By jdbc specification the methods: 
1. java.sql.ResultSet#getByte(int)
2. java.sql.ResultSet#getShort(int)
3. java.sql.ResultSet#getInt(int)
4. java.sql.ResultSet#getLong(int)
5. java.sql.ResultSet#getFloat(int)
6. java.sql.ResultSet#getDouble(int)

must returned 0, if the value is SQL=NULL

And by anology
1. java.sql.ResultSet#getBigDecimal(int)
2. java.sql.ResultSet#getTime(int)
3. java.sql.ResultSet#getDate(int)
4. java.sql.ResultSet#getTimestamp(int)
5. java.sql.ResultSet#getURL(int) unsupported now
6. java.sql.ResultSet#getAsciiStream(int) unsupported now

must returned null, if the value is SQL=NULL

This PR fix it issue.