### PR TITLE
Fix getColumnsSize for LowCardinality(FixedString)

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
+++ b/src/main/java/ru/yandex/clickhouse/util/TypeUtils.java
@@ -186,6 +186,9 @@ public class TypeUtils {
         } else if (type.startsWith("FixedString(")) {
             String numBytes = type.substring("FixedString(".length(), type.length() - 1);
             return Integer.parseInt(numBytes);
+        } else if (type.startsWith("LowCardinality(FixedString(")) {
+            String numBytes = type.substring("LowCardinality(FixedString(".length(), type.length() - 2);
+            return Integer.parseInt(numBytes);
         } else if (type.startsWith("Decimal(")) {
             Matcher m = DECIMAL_PATTERN.matcher(type);
             return m.matches() ? Integer.parseInt(m.group(1)) : 0;


### PR DESCRIPTION
Without true detection of column size it's impossible to auto replicate to storage that supports only VARCHAR that needed to provide actual column size.