### PR TITLE
Added support for paths in URL

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -649,7 +649,7 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
                 .setScheme(properties.getSsl() ? "https" : "http")
                 .setHost(properties.getHost())
                 .setPort(properties.getPort())
-                .setPath("/")
+                .setPath((properties.getPath() == null || properties.getPath().isEmpty() ? "/" : properties.getPath()))
                 .setParameters(queryParams)
                 .build();
         } catch (URISyntaxException e) {

--- a/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParser.java
@@ -44,18 +44,29 @@ public class ClickhouseJdbcUrlParser {
         props.setPort(port);
         String path = uri.getPath();
         String database;
-        if (path == null || path.isEmpty() || path.equals("/")) {
-            String defaultsDb = defaults.getProperty(ClickHouseQueryParam.DATABASE.getKey());
-            database = defaultsDb == null ? DEFAULT_DATABASE : defaultsDb;
-        } else {
-            Matcher m = DB_PATH_PATTERN.matcher(path);
-            if (m.matches()) {
-                database = m.group(1);
+        if (props.isUsePathAsDb()) {
+            if (path == null || path.isEmpty() || path.equals("/")) {
+                String defaultsDb = defaults.getProperty(ClickHouseQueryParam.DATABASE.getKey());
+                database = defaultsDb == null ? DEFAULT_DATABASE : defaultsDb;
             } else {
-                throw new URISyntaxException("wrong database name path: '" + path + "'", uriString);
+                Matcher m = DB_PATH_PATTERN.matcher(path);
+                if (m.matches()) {
+                    database = m.group(1);
+                } else {
+                    throw new URISyntaxException("wrong database name path: '" + path + "'", uriString);
+                }
+            }
+            props.setDatabase(database);
+        } else {
+            if (props.getDatabase() == null || props.getDatabase().isEmpty()) {
+                props.setDatabase(DEFAULT_DATABASE);
+            }
+            if (path == null || path.isEmpty()) {
+                props.setPath("/");
+            } else {
+                props.setPath(path);
             }
         }
-        props.setDatabase(database);
         return props;
     }
 

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -14,6 +14,8 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
     SSL("ssl", false, "enable SSL/TLS for the connection"),
     SSL_ROOT_CERTIFICATE("sslrootcert", "", "SSL/TLS root certificate"),
     SSL_MODE("sslmode", "strict", "verify or not certificate: none (don't verify), strict (verify)"),
+    USE_PATH_AS_DB("use_path_as_db", true, "whether URL path should be treated as database name"),
+    PATH("path", "/", "URL path"),
 
     /*
     *

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -23,6 +23,8 @@ public class ClickHouseProperties {
     private int maxTotal;
     private String host;
     private int port;
+    private boolean usePathAsDb;
+    private String path;
     private boolean ssl;
     private String sslRootCertificate;
     private String sslMode;
@@ -94,6 +96,8 @@ public class ClickHouseProperties {
         this.ssl = (Boolean) getSetting(info, ClickHouseConnectionSettings.SSL);
         this.sslRootCertificate = (String) getSetting(info, ClickHouseConnectionSettings.SSL_ROOT_CERTIFICATE);
         this.sslMode = (String) getSetting(info, ClickHouseConnectionSettings.SSL_MODE);
+        this.usePathAsDb = (Boolean) getSetting(info, ClickHouseConnectionSettings.USE_PATH_AS_DB);
+        this.path = (String) getSetting(info, ClickHouseConnectionSettings.PATH);
         this.useServerTimeZone = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE);
         this.useTimeZone = (String)getSetting(info, ClickHouseConnectionSettings.USE_TIME_ZONE);
         this.useServerTimeZoneForDates = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES);
@@ -153,6 +157,8 @@ public class ClickHouseProperties {
         ret.put(ClickHouseConnectionSettings.SSL.getKey(), String.valueOf(ssl));
         ret.put(ClickHouseConnectionSettings.SSL_ROOT_CERTIFICATE.getKey(), String.valueOf(sslRootCertificate));
         ret.put(ClickHouseConnectionSettings.SSL_MODE.getKey(), String.valueOf(sslMode));
+        ret.put(ClickHouseConnectionSettings.USE_PATH_AS_DB.getKey(), String.valueOf(usePathAsDb));
+        ret.put(ClickHouseConnectionSettings.PATH.getKey(), String.valueOf(path));
         ret.put(ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE.getKey(), String.valueOf(useServerTimeZone));
         ret.put(ClickHouseConnectionSettings.USE_TIME_ZONE.getKey(), String.valueOf(useTimeZone));
         ret.put(ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES.getKey(), String.valueOf(useServerTimeZoneForDates));
@@ -215,6 +221,8 @@ public class ClickHouseProperties {
         setSsl(properties.ssl);
         setSslRootCertificate(properties.sslRootCertificate);
         setSslMode(properties.sslMode);
+        setUsePathAsDb(properties.usePathAsDb);
+        setPath(properties.path);
         setUseServerTimeZone(properties.useServerTimeZone);
         setUseTimeZone(properties.useTimeZone);
         setUseServerTimeZoneForDates(properties.useServerTimeZoneForDates);
@@ -688,6 +696,22 @@ public class ClickHouseProperties {
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    public boolean isUsePathAsDb() {
+        return usePathAsDb;
+    }
+
+    public void setUsePathAsDb(boolean usePathAsDb) {
+        this.usePathAsDb = usePathAsDb;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 
     public boolean isDistributedAggregationMemoryEfficient() {

--- a/src/test/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParserTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickhouseJdbcUrlParserTest.java
@@ -25,4 +25,65 @@ public class ClickhouseJdbcUrlParserTest {
         Assert.assertEquals(chProps.getDatabase(), "default");
     }
 
+    @Test
+    public void testParseDbInPathAndProps() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setDatabase("database-name");
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337/database-name", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "database-name");
+        Assert.assertEquals(chProps.getPath(), "/");
+    }
+
+    @Test
+    public void testParseDbInPathAndProps2() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setDatabase("database-name");
+        props.setUsePathAsDb(false);
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337/database-name", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "database-name");
+        Assert.assertEquals(chProps.getPath(), "/database-name");
+    }
+
+    @Test
+    public void testParsePathDefaultDb() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setPath("/path");
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337/", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "default");
+        Assert.assertEquals(chProps.getPath(), "/path");
+    }
+
+    @Test
+    public void testParsePathDefaultDb2() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setPath("/path");
+        props.setUsePathAsDb(false);
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "default");
+        Assert.assertEquals(chProps.getPath(), "/"); //uri takes priority
+    }
+
+    @Test
+    public void testParsePathAndDb() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337/db?database=dbname", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "db");
+        Assert.assertEquals(chProps.getPath(), "/");
+    }
+
+    @Test
+    public void testParsePathAndDb2() throws Exception {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUsePathAsDb(false);
+        ClickHouseProperties chProps = ClickhouseJdbcUrlParser.parse(
+            "jdbc:clickhouse://foo.yandex:1337/db?database=dbname", props.asProperties());
+        Assert.assertEquals(chProps.getDatabase(), "dbname");
+        Assert.assertEquals(chProps.getPath(), "/db");
+    }
+
 }


### PR DESCRIPTION
Support for URLs like `http://example.com/some/path?database=dbname`

Can be enabled by setting `usePathAsDb` to `false`. If set, `/some/path` will be treated as path instead of database name. Database name in turn can be given using `ClickHouseProperties` object, or with `?database=` parameter in URL.