### PR TITLE
Speeded up setBoolean 10x times

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -1,47 +1,25 @@
 package ru.yandex.clickhouse;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.math.BigDecimal;
-import java.net.URL;
-import java.sql.Array;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
-import java.sql.NClob;
-import java.sql.ParameterMetaData;
-import java.sql.Ref;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.RowId;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLSyntaxErrorException;
-import java.sql.SQLXML;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-
 import ru.yandex.clickhouse.response.ClickHouseResponse;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
 import ru.yandex.clickhouse.util.ClickHouseArrayUtil;
 import ru.yandex.clickhouse.util.ClickHouseValueFormatter;
 import ru.yandex.clickhouse.util.guava.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Date;
+import java.sql.*;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl implements ClickHousePreparedStatement {
@@ -166,12 +144,12 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
 
     @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        setBind(parameterIndex, ClickHouseValueFormatter.formatNull(), false);
+        setNull(parameterIndex);
     }
 
     @Override
     public void setBoolean(int parameterIndex, boolean x) throws SQLException {
-        setBind(parameterIndex, ClickHouseValueFormatter.formatBoolean(x), false);
+        setBind(parameterIndex, ClickHousePreparedStatementParameter.boolParameter(x));
     }
 
     @Override

--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameter.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameter.java
@@ -1,13 +1,19 @@
 package ru.yandex.clickhouse;
 
-import java.util.TimeZone;
-
 import ru.yandex.clickhouse.util.ClickHouseValueFormatter;
+
+import java.util.TimeZone;
 
 public final class ClickHousePreparedStatementParameter {
 
     private static final ClickHousePreparedStatementParameter NULL_PARAM =
         new ClickHousePreparedStatementParameter(null, false);
+
+    private static final ClickHousePreparedStatementParameter TRUE_PARAM =
+            new ClickHousePreparedStatementParameter("1", false);
+
+    private static final ClickHousePreparedStatementParameter FALSE_PARAM =
+            new ClickHousePreparedStatementParameter("0", false);
 
     private final String stringValue;
     private final boolean quoteNeeded;
@@ -25,6 +31,10 @@ public final class ClickHousePreparedStatementParameter {
 
     public static ClickHousePreparedStatementParameter nullParameter() {
         return NULL_PARAM;
+    }
+
+    public static ClickHousePreparedStatementParameter boolParameter(boolean value) {
+        return value ? TRUE_PARAM : FALSE_PARAM;
     }
 
     public ClickHousePreparedStatementParameter(String stringValue,
@@ -47,6 +57,7 @@ public final class ClickHousePreparedStatementParameter {
     String getBatchValue() {
         return stringValue;
     }
+
 
     @Override
     public String toString() {

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
@@ -1,5 +1,8 @@
 package ru.yandex.clickhouse.util;
 
+import ru.yandex.clickhouse.ClickHouseArray;
+import ru.yandex.clickhouse.ClickHouseUtil;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
@@ -9,9 +12,6 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.TimeZone;
 import java.util.UUID;
-
-import ru.yandex.clickhouse.ClickHouseArray;
-import ru.yandex.clickhouse.ClickHouseUtil;
 
 public final class ClickHouseValueFormatter {
 


### PR DESCRIPTION
Following pipeline:
1.) String value = bool ? "1" : "0"
2.) Create new parameter holder for value
Replaced with:
bool ? trueParameter : falseParameter.
Got performance increase 10x times for setBoolean() sequential call.
@enqueue , FYI.